### PR TITLE
Increase modularity of COS

### DIFF
--- a/semeio/jobs/correlated_observations_scaling/exceptions.py
+++ b/semeio/jobs/correlated_observations_scaling/exceptions.py
@@ -1,2 +1,8 @@
 class EmptyDatasetException(ValueError):
     pass
+
+
+class ValidationError(ValueError):
+    def __init__(self, message, errors):
+        super(ValidationError, self).__init__(message)
+        self.errors = errors

--- a/semeio/jobs/correlated_observations_scaling/job.py
+++ b/semeio/jobs/correlated_observations_scaling/job.py
@@ -1,232 +1,99 @@
 # -*- coding: utf-8 -*-
-import fnmatch
-
 import configsuite
-
-from copy import deepcopy
-from collections import namedtuple
-
 from semeio.jobs.correlated_observations_scaling import job_config
-from semeio.jobs.correlated_observations_scaling.scaled_matrix import DataMatrix
-from ert_data.measured import MeasuredData
-from semeio.jobs.correlated_observations_scaling.validator import (
-    valid_configuration,
-    valid_job,
+from semeio.jobs.correlated_observations_scaling.exceptions import ValidationError
+from semeio.jobs.correlated_observations_scaling.obs_utils import (
+    create_active_lists,
+    find_and_expand_wildcards,
 )
-from res.enkf import LocalObsdata, ActiveList
-
-from ecl.util.util import BoolVector
-from res.enkf import RealizationStateEnum
+from semeio.jobs.correlated_observations_scaling.scaled_matrix import DataMatrix
+from semeio.jobs.correlated_observations_scaling.validator import has_keys, is_subset
 
 
-def scaling_job(facade, user_config_dict):
-    """
-    Takes an instance of EnkFMain and a user config dict, will do some pre-processing on
-    the user config dict, set up a ConfigSuite instance and validate the job before control
-    is passed to the main job.
-    """
+class ScalingJob(object):
+    def __init__(self, obs_keys, obs, obs_with_data, user_config_dict):
+        """Creates a ScalingJob instance with the given obs_keys, obs,
+        obs_with_data and user_config_dict."""
+        self._obs = obs
+        self._obs_with_data = obs_with_data
+        self._obs_keys = obs_keys
+        self._config = self._setup_configuration(user_config_dict)
+        self._validate()
 
-    observation_keys = [
-        facade.get_observation_key(nr) for nr, _ in enumerate(facade.get_observations())
-    ]
-    obs_with_data = keys_with_data(
-        facade.get_observations(),
-        observation_keys,
-        facade.get_ensemble_size(),
-        facade.get_current_fs(),
-    )
-    config_dict = _find_and_expand_wildcards(observation_keys, user_config_dict)
+    def scale(self, measured_data):
+        """
+        Collects data, performs scaling and applies scaling, assumes validated input.
+        """
+        config = self._config.snapshot
 
-    config = setup_configuration(config_dict, job_config.build_schema())
+        measured_data.remove_failed_realizations()
+        measured_data.remove_inactive_observations()
+        measured_data.filter_ensemble_mean_obs(config.CALCULATE_KEYS.alpha)
+        measured_data.filter_ensemble_std(config.CALCULATE_KEYS.std_cutoff)
 
-    if not valid_configuration(config):
-        raise ValueError("Invalid configuration")
-    if not valid_job(config, observation_keys, obs_with_data):
-        raise ValueError("Invalid job")
-    _observation_scaling(facade, config.snapshot)
+        matrix = DataMatrix(measured_data.data)
+        matrix.std_normalization(inplace=True)
 
+        scale_factor = matrix.get_scaling_factor(config.CALCULATE_KEYS)
 
-def _observation_scaling(facade, config):
-    """
-    Collects data, performs scaling and applies scaling, assumes validated input.
-    """
-    calculate_keys = [event.key for event in config.CALCULATE_KEYS.keys]
-    index_lists = [event.index for event in config.CALCULATE_KEYS.keys]
-    measured_data = MeasuredData(facade, calculate_keys, index_lists)
-    measured_data.remove_failed_realizations()
-    measured_data.remove_inactive_observations()
-    measured_data.filter_ensemble_mean_obs(config.CALCULATE_KEYS.alpha)
-    measured_data.filter_ensemble_std(config.CALCULATE_KEYS.std_cutoff)
+        update_data = create_active_lists(self._obs, config.UPDATE_KEYS.keys)
+        self._update_scaling(self._obs, scale_factor, update_data)
 
-    matrix = DataMatrix(measured_data.data)
-    matrix.std_normalization(inplace=True)
+    def _validate(self):
+        """
+        Validates the job. If invalid, raises an ValidationError.
+        """
+        errors = [] if self._config.valid else self._config.errors
+        calc_keys = self.get_calc_keys()
+        application_keys = [
+            entry.key for entry in self._config.snapshot.UPDATE_KEYS.keys
+        ]
 
-    scale_factor = matrix.get_scaling_factor(config.CALCULATE_KEYS)
-
-    update_data = _create_active_lists(
-        facade.get_observations(), config.UPDATE_KEYS.keys
-    )
-
-    _update_scaling(facade.get_observations(), scale_factor, update_data)
-
-
-def _wildcard_to_dict_list(matching_keys, entry):
-    """
-    One of either:
-    entry = {"key": "WOPT*", "index": [1,2,3]}
-    entry = {"key": "WOPT*"}
-    """
-    if "index" in entry:
-        return [{"key": key, "index": entry["index"]} for key in matching_keys]
-    else:
-        return [{"key": key} for key in matching_keys]
-
-
-def _expand_wildcard(obs_list, wildcard_key, entry):
-    """
-    Expands a wildcard
-    """
-    matching_keys = fnmatch.filter(obs_list, wildcard_key["key"])
-    return _wildcard_to_dict_list(matching_keys, entry)
-
-
-def _find_and_expand_wildcards(obs_list, user_dict):
-    """
-    Loops through the user input and identifies wildcards in observation
-    names and expands them.
-    """
-    new_dict = deepcopy(user_dict)
-    for main_key, value in user_dict.items():
-        new_entries = []
-        if main_key in ("UPDATE_KEYS", "CALCULATE_KEYS"):
-            for val in value["keys"]:
-                if "*" in val["key"]:
-                    new_entries.extend(_expand_wildcard(obs_list, val, val["key"]))
-                else:
-                    new_entries.append(val)
-            new_dict[main_key]["keys"] = new_entries
-
-    return new_dict
-
-
-def setup_configuration(input_data, schema):
-    """
-    Creates a ConfigSuite instance and inserts default values
-    """
-    default_layer = job_config.get_default_values()
-    config = configsuite.ConfigSuite(input_data, schema, layers=(default_layer,))
-    return config
-
-
-def _create_active_lists(enkf_observations, events):
-    """
-    Will add observation vectors to observation data. Returns
-    a list of tuples mirroring the user config but also containing
-    the active list where the scaling factor will be applied.
-    """
-    new_events = []
-    observation_data = LocalObsdata("some_name", enkf_observations)
-    for event in events:
-        observation_data.addObsVector(enkf_observations[event.key])
-
-        obs_index = _data_index_to_obs_index(enkf_observations, event.key, event.index)
-        new_active_list = _get_active_list(observation_data, event.key, obs_index)
-
-        new_events.append(_make_tuple(event.key, event.index, new_active_list))
-
-    return new_events
-
-
-def _get_active_list(observation_data, key, index_list):
-    """
-    If the user doesn't supply an index list, the existing active
-    list from the observation is used, otherwise an active list is
-    created from the index list.
-    """
-    if index_list is not None:
-        return _active_list_from_index_list(index_list)
-    else:
-        return observation_data.copy_active_list(key).setParent()
-
-
-def _make_tuple(
-    key,
-    index,
-    active_list,
-    new_event=namedtuple("named_dict", ["key", "index", "active_list"]),
-):
-    return new_event(key, index, active_list)
-
-
-def _update_scaling(obs, scale_factor, events):
-    """
-    Applies the scaling factor to the user specified index, SUMMARY_OBS needs to be treated differently
-    as it only has one data point per node, compared with other observation types which have multiple
-    data points per node.
-    """
-    for event in events:
-        obs_vector = obs[event.key]
-        for index, obs_node in enumerate(obs_vector):
-            if obs_vector.getImplementationType().name == "SUMMARY_OBS":
-                index_list = (
-                    event.index if event.index is not None else range(len(obs_vector))
-                )
-                if index in index_list:
-                    obs_node.set_std_scaling(scale_factor)
-            elif obs_vector.getImplementationType().name != "SUMMARY_OBS":
-                obs_node.updateStdScaling(scale_factor, event.active_list)
-    print(
-        "Keys: {} scaled with scaling factor: {}".format(
-            [event.key for event in events], scale_factor
+        errors.extend(is_subset(calc_keys, application_keys))
+        errors.extend(
+            has_keys(self._obs_keys, calc_keys, "Key: {} has no observations")
         )
-    )
+        errors.extend(has_keys(self._obs_with_data, calc_keys, "Key: {} has no data"))
+        if len(errors) > 0:
+            raise ValidationError("Invalid job", errors)
 
+    def get_calc_keys(self):
+        return [event.key for event in self._config.snapshot.CALCULATE_KEYS.keys]
 
-def _active_list_from_index_list(index_list):
-    """
-    Creates an ActiveList from a list of indexes
-    :param index_list: list of index
-    :type index_list:  list
-    :return: Active list, a c-object with mode (ALL-ACTIVE, PARTIALLY-ACTIVE, INACTIVE) and list of indices
-    :rtype: active_list
-    """
-    active_list = ActiveList()
-    [active_list.addActiveIndex(index) for index in index_list]
-    return active_list
+    def get_index_lists(self):
+        return [event.index for event in self._config.snapshot.CALCULATE_KEYS.keys]
 
+    def _setup_configuration(self, config_data):
+        """
+        Creates a ConfigSuite instance and inserts default values
+        """
+        schema = job_config.build_schema()
+        config_dict = find_and_expand_wildcards(self._obs_keys, config_data)
+        default_layer = job_config.get_default_values()
+        config = configsuite.ConfigSuite(config_dict, schema, layers=(default_layer,))
+        return config
 
-def _set_active_lists(observation_data, key_list, active_lists):
-    """
-    Will make a backup of the existing active list on the observation node
-    before setting the user supplied index list.
-    """
-    exisiting_active_lists = []
-    for key, active_list in zip(key_list, active_lists):
-        exisiting_active_lists.append(observation_data.copy_active_list(key))
-        observation_data.setActiveList(key, active_list)
-    return observation_data, exisiting_active_lists
-
-
-def keys_with_data(observations, keys, ensamble_size, storage):
-    """
-    Checks that all keys have data and returns a list of error messages
-    """
-    active_realizations = storage.realizationList(RealizationStateEnum.STATE_HAS_DATA)
-
-    if len(active_realizations) == 0:
-        return []
-
-    active_mask = BoolVector.createFromList(ensamble_size, active_realizations)
-    return [key for key in keys if observations[key].hasData(active_mask, storage)]
-
-
-def _data_index_to_obs_index(obs, obs_key, data_index_list):
-    if obs[obs_key].getImplementationType().name != "GEN_OBS":
-        return data_index_list
-    elif data_index_list is None:
-        return data_index_list
-
-    for timestep in obs[obs_key].getStepList().asList():
-        node = obs[obs_key].getNode(timestep)
-        index_map = {node.getIndex(nr): nr for nr in range(len(node))}
-    return [index_map[index] for index in data_index_list]
+    def _update_scaling(self, obs, scale_factor, events):
+        """
+        Applies the scaling factor to the user specified index, SUMMARY_OBS needs to be treated differently
+        as it only has one data point per node, compared with other observation types which have multiple
+        data points per node.
+        """
+        for event in events:
+            obs_vector = obs[event.key]
+            for index, obs_node in enumerate(obs_vector):
+                if obs_vector.getImplementationType().name == "SUMMARY_OBS":
+                    index_list = (
+                        event.index
+                        if event.index is not None
+                        else range(len(obs_vector))
+                    )
+                    if index in index_list:
+                        obs_node.set_std_scaling(scale_factor)
+                elif obs_vector.getImplementationType().name != "SUMMARY_OBS":
+                    obs_node.updateStdScaling(scale_factor, event.active_list)
+        print(
+            "Keys: {} scaled with scaling factor: {}".format(
+                [event.key for event in events], scale_factor
+            )
+        )

--- a/semeio/jobs/correlated_observations_scaling/job_config.py
+++ b/semeio/jobs/correlated_observations_scaling/job_config.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-import configsuite
-import six
-
+import os
 from copy import deepcopy
 
+import six
+
+import configsuite
 from configsuite import MetaKeys as MK
 from configsuite import types
 

--- a/semeio/jobs/correlated_observations_scaling/obs_utils.py
+++ b/semeio/jobs/correlated_observations_scaling/obs_utils.py
@@ -1,0 +1,136 @@
+import fnmatch
+from collections import namedtuple
+from copy import deepcopy
+
+from ecl.util.util import BoolVector
+from res.enkf import ActiveList, LocalObsdata, RealizationStateEnum
+
+
+def _wildcard_to_dict_list(matching_keys, entry):
+    """
+    One of either:
+    entry = {"key": "WOPT*", "index": [1,2,3]}
+    entry = {"key": "WOPT*"}
+    """
+    if "index" in entry:
+        return [{"key": key, "index": entry["index"]} for key in matching_keys]
+    else:
+        return [{"key": key} for key in matching_keys]
+
+
+def _expand_wildcard(obs_list, wildcard_key, entry):
+    """
+    Expands a wildcard
+    """
+    matching_keys = fnmatch.filter(obs_list, wildcard_key["key"])
+    return _wildcard_to_dict_list(matching_keys, entry)
+
+
+def find_and_expand_wildcards(obs_list, user_dict):
+    """
+    Loops through the user input and identifies wildcards in observation
+    names and expands them.
+    """
+    new_dict = deepcopy(user_dict)
+    for main_key, value in user_dict.items():
+        new_entries = []
+        if main_key in ("UPDATE_KEYS", "CALCULATE_KEYS"):
+            for val in value["keys"]:
+                if "*" in val["key"]:
+                    new_entries.extend(_expand_wildcard(obs_list, val, val["key"]))
+                else:
+                    new_entries.append(val)
+            new_dict[main_key]["keys"] = new_entries
+
+    return new_dict
+
+
+def create_active_lists(enkf_observations, events):
+    """
+    Will add observation vectors to observation data. Returns
+    a list of tuples mirroring the user config but also containing
+    the active list where the scaling factor will be applied.
+    """
+    new_events = []
+    observation_data = LocalObsdata("some_name", enkf_observations)
+    for event in events:
+        observation_data.addObsVector(enkf_observations[event.key])
+
+        obs_index = _data_index_to_obs_index(enkf_observations, event.key, event.index)
+        new_active_list = _get_active_list(observation_data, event.key, obs_index)
+
+        new_events.append(_make_tuple(event.key, event.index, new_active_list))
+
+    return new_events
+
+
+def _get_active_list(observation_data, key, index_list):
+    """
+    If the user doesn't supply an index list, the existing active
+    list from the observation is used, otherwise an active list is
+    created from the index list.
+    """
+    if index_list is not None:
+        return _active_list_from_index_list(index_list)
+    else:
+        return observation_data.copy_active_list(key).setParent()
+
+
+def _make_tuple(
+    key,
+    index,
+    active_list,
+    new_event=namedtuple("named_dict", ["key", "index", "active_list"]),
+):
+    return new_event(key, index, active_list)
+
+
+def _active_list_from_index_list(index_list):
+    """
+    Creates an ActiveList from a list of indexes
+    :param index_list: list of index
+    :type index_list:  list
+    :return: Active list, a c-object with mode (ALL-ACTIVE, PARTIALLY-ACTIVE, INACTIVE) and list of indices
+    :rtype: active_list
+    """
+    active_list = ActiveList()
+    for index in index_list:
+        active_list.addActiveIndex(index)
+    return active_list
+
+
+def _set_active_lists(observation_data, key_list, active_lists):
+    """
+    Will make a backup of the existing active list on the observation node
+    before setting the user supplied index list.
+    """
+    exisiting_active_lists = []
+    for key, active_list in zip(key_list, active_lists):
+        exisiting_active_lists.append(observation_data.copy_active_list(key))
+        observation_data.setActiveList(key, active_list)
+    return observation_data, exisiting_active_lists
+
+
+def keys_with_data(observations, keys, ensamble_size, storage):
+    """
+    Checks that all keys have data and returns a list of error messages
+    """
+    active_realizations = storage.realizationList(RealizationStateEnum.STATE_HAS_DATA)
+
+    if len(active_realizations) == 0:
+        return []
+
+    active_mask = BoolVector.createFromList(ensamble_size, active_realizations)
+    return [key for key in keys if observations[key].hasData(active_mask, storage)]
+
+
+def _data_index_to_obs_index(obs, obs_key, data_index_list):
+    if obs[obs_key].getImplementationType().name != "GEN_OBS":
+        return data_index_list
+    elif data_index_list is None:
+        return data_index_list
+
+    for timestep in obs[obs_key].getStepList().asList():
+        node = obs[obs_key].getNode(timestep)
+        index_map = {node.getIndex(nr): nr for nr in range(len(node))}
+    return [index_map[index] for index in data_index_list]

--- a/semeio/jobs/correlated_observations_scaling/validator.py
+++ b/semeio/jobs/correlated_observations_scaling/validator.py
@@ -1,30 +1,11 @@
-def valid_job(user_config, obs_list, obs_with_data):
-    """
-    Validates the job, assumes that the configuration is valid
-    """
-
-    calc_keys = [entry.key for entry in user_config.snapshot.CALCULATE_KEYS.keys]
-    application_keys = [entry.key for entry in user_config.snapshot.UPDATE_KEYS.keys]
-
-    error_messages = []
-
-    error_messages.extend(_is_subset(calc_keys, application_keys))
-    error_messages.extend(_has_keys(obs_list, calc_keys, "Key: {} has no observations"))
-    error_messages.extend(_has_keys(obs_with_data, calc_keys, "Key: {} has no data"))
-
-    for error in error_messages:
-        print(error)
-    return len(error_messages) == 0
-
-
-def _has_keys(main_list, sub_list, error_msg):
+def has_keys(main_list, sub_list, error_msg):
     """
     Checks that all sub_list are present and returns a list of error messages
     """
     return [error_msg.format(key) for key in sub_list if key not in main_list]
 
 
-def _is_subset(main_list, sub_list):
+def is_subset(main_list, sub_list):
     """
     Checks if all the keys in sub_list are present in main_list and returns list of error
     messages
@@ -32,12 +13,3 @@ def _is_subset(main_list, sub_list):
     error_msg = "Update key: {} missing from calculate keys: {}"
     missing_keys = set(sub_list).difference(set(main_list))
     return [error_msg.format(missing_key, main_list) for missing_key in missing_keys]
-
-
-def valid_configuration(user_config):
-    """
-    Validates the configuration
-    """
-    for error in user_config.errors:
-        print(error)
-    return user_config.valid

--- a/semeio/jobs/scripts/correlated_observations_scaling.py
+++ b/semeio/jobs/scripts/correlated_observations_scaling.py
@@ -1,25 +1,49 @@
 import collections
 
 import yaml
+
+from ert_data.measured import MeasuredData
 from ert_shared.libres_facade import LibresFacade
 from res.enkf import ErtScript
-
-from semeio.jobs.correlated_observations_scaling.job import scaling_job
+from semeio.jobs.correlated_observations_scaling.exceptions import ValidationError
+from semeio.jobs.correlated_observations_scaling.job import ScalingJob
+from semeio.jobs.correlated_observations_scaling.obs_utils import keys_with_data
 
 
 class CorrelatedObservationsScalingJob(ErtScript):
-    def run(self, job_config_file):
+    def run(self, job_config):
         facade = LibresFacade(self.ert())
-        user_config = load_yaml(job_config_file)
+        user_config = load_yaml(job_config)
         user_config = _insert_default_group(user_config)
-        for job_config in user_config:
-            scaling_job(facade, job_config)
+
+        obs = facade.get_observations()
+        obs_keys = [facade.get_observation_key(nr) for nr, _ in enumerate(obs)]
+        obs_with_data = keys_with_data(
+            obs, obs_keys, facade.get_ensemble_size(), facade.get_current_fs(),
+        )
+
+        for config in user_config:
+            try:
+                job = ScalingJob(obs_keys, obs, obs_with_data, config)
+            except ValidationError as validation_error:
+                print(str(validation_error))
+                for error in validation_error.errors:
+                    print("\t{}".format(error))
+                continue
+
+            measured_data = MeasuredData(
+                facade, job.get_calc_keys(), job.get_index_lists()
+            )
+            job.scale(measured_data)
 
 
-def load_yaml(f_name):
-    with open(f_name, "r") as fin:
-        config = yaml.safe_load(fin)
-    return config
+def load_yaml(job_config):
+    # Allow job_config to be both list and dict.
+    if isinstance(job_config, dict) or isinstance(job_config, list):
+        return job_config
+
+    with open(job_config, "r") as fin:
+        return yaml.safe_load(fin)
 
 
 def _insert_default_group(value):

--- a/semeio/jobs/scripts/spearman_correlation.py
+++ b/semeio/jobs/scripts/spearman_correlation.py
@@ -1,8 +1,12 @@
 import argparse
 
+from ert_data.measured import MeasuredData
 from ert_shared.libres_facade import LibresFacade
 from res.enkf import ErtScript
-
+from semeio.jobs.correlated_observations_scaling.exceptions import EmptyDatasetException
+from semeio.jobs.scripts.correlated_observations_scaling import (
+    CorrelatedObservationsScalingJob,
+)
 from semeio.jobs.spearman_correlation_job.job import spearman_job
 
 
@@ -10,10 +14,22 @@ class SpearmanCorrelationJob(ErtScript):
     def run(self, *args):
         facade = LibresFacade(self.ert())
 
+        obs_keys = [
+            facade.get_observation_key(nr)
+            for nr, _ in enumerate(facade.get_observations())
+        ]
+        measured_data = MeasuredData(facade, obs_keys)
+
         parser = spearman_job_parser()
         args = parser.parse_args(args)
 
-        spearman_job(facade, args.threshold, args.dry_run)
+        scaling_configs = spearman_job(measured_data, args.threshold)
+
+        if not args.dry_run:
+            try:
+                CorrelatedObservationsScalingJob(self.ert()).run(scaling_configs)
+            except EmptyDatasetException:
+                pass
 
 
 def spearman_job_parser():

--- a/tests/jobs/correlated_observations_scaling/conftest.py
+++ b/tests/jobs/correlated_observations_scaling/conftest.py
@@ -28,3 +28,11 @@ def setup_ert(tmpdir):
     yield res_config
 
     os.chdir(cwd)
+
+
+@pytest.fixture()
+def setup_tmpdir(tmpdir):
+    cwd = os.getcwd()
+    tmpdir.chdir()
+    yield
+    os.chdir(cwd)

--- a/tests/jobs/correlated_observations_scaling/unit/test_config.py
+++ b/tests/jobs/correlated_observations_scaling/unit/test_config.py
@@ -1,0 +1,113 @@
+from copy import deepcopy
+
+import pytest
+import configsuite
+
+from semeio.jobs.correlated_observations_scaling.job_config import (
+    _expand_input,
+    _min_value,
+    _to_int_list,
+    build_schema,
+)
+
+
+@pytest.mark.parametrize(
+    "valid_input",
+    [
+        "0,1,2-5",
+        [0, 1, "2-5"],
+        [0, 1, 2, 3, 4, 5],
+        [0, 1, "2-3", "4-5"],
+        "0-5",
+        "0-1,2,3-5",
+        ["0,1,2-5"],
+    ],
+)
+def test_to_int_list(valid_input):
+    expected_result = list(range(6))
+    assert _to_int_list(valid_input) == expected_result
+
+
+@pytest.mark.parametrize(
+    "test_input,expected_result", [(-1, False), (0, True), (1, True)]
+)
+def test_min_value(test_input, expected_result):
+    assert _min_value(test_input).__bool__() == expected_result
+
+
+def test_expand_input_no_modification():
+    expected_result = {
+        "UPDATE_KEYS": {"keys": [{"key": "key_4"}, {"key": "key_5"}, {"key": "key_6"}]},
+        "CALCULATE_KEYS": {
+            "keys": [{"key": "key_1"}, {"key": "key_2"}, {"key": "key_3"}],
+            "threshold": 1.0,
+        },
+    }
+
+    assert _expand_input(deepcopy(expected_result)) == expected_result
+
+
+def test_expand_input_modification():
+    keys = [{"key": "key_1"}, {"key": "key_2"}, {"key": "key_3"}]
+    test_input = {"CALCULATE_KEYS": {"keys": keys, "threshold": 1.0}}
+
+    expected_results = deepcopy(test_input)
+    expected_results["UPDATE_KEYS"] = {"keys": keys}
+
+    assert _expand_input(test_input) == expected_results
+
+
+def test_config_setup():
+
+    valid_config_data = {
+        "CALCULATE_KEYS": {"keys": [{"key": "first_key"}, {"key": "second_key"}]}
+    }
+
+    schema = build_schema()
+    config = configsuite.ConfigSuite(valid_config_data, schema)
+    assert config.valid
+
+    valid_config_data = {
+        "CALCULATE_KEYS": {"keys": [{"key": "first_key"}, {"key": "second_key"}]},
+        "UPDATE_KEYS": {"keys": [{"index": [1, 2, 3], "key": "first_key"}]},
+    }
+
+    schema = build_schema()
+    config = configsuite.ConfigSuite(valid_config_data, schema)
+    assert config.valid
+
+    invalid_too_short_index_list = {
+        "UPDATE_KEYS": {"keys": [{"index": "1", "key": ["a_key"]}]}
+    }
+
+    config = configsuite.ConfigSuite(invalid_too_short_index_list, schema)
+    assert not config.valid
+
+    invalid_missing_required_keyword = {
+        "CALCULATE_KEYS": {"keys": [{"key": "a_key"}]},
+        "UPDATE_KEYS": {"index": "1-5"},
+    }
+
+    config = configsuite.ConfigSuite(invalid_missing_required_keyword, schema)
+    assert not config.valid
+
+    invalid_negative_index = {
+        "CALCULATE_KEYS": {"keys": [{"key": "first_key"}, {"key": "second_key"}]},
+        "UPDATE_KEYS": {"keys": [{"index": [-1, 2, 3], "key": "first_key"}]},
+    }
+
+    schema = build_schema()
+    config = configsuite.ConfigSuite(invalid_negative_index, schema)
+    assert not config.valid
+
+
+def test_valid_configuration():
+    valid_config_data = {
+        "CALCULATE_KEYS": {"keys": [{"key": "POLY_OBS"}]},
+        "UPDATE_KEYS": {"keys": [{"key": "POLY_OBS"}]},
+    }
+
+    schema = build_schema()
+    config = configsuite.ConfigSuite(valid_config_data, schema)
+
+    assert config.valid

--- a/tests/jobs/correlated_observations_scaling/unit/test_scaled_matrix.py
+++ b/tests/jobs/correlated_observations_scaling/unit/test_scaled_matrix.py
@@ -1,0 +1,38 @@
+from collections import namedtuple
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from semeio.jobs.correlated_observations_scaling.scaled_matrix import DataMatrix
+
+
+def test_get_scaling_factor():
+    new_event = namedtuple("named_dict", ["keys", "threshold"])
+    event = new_event(["one_random_key"], 0.95)
+    np.random.seed(123)
+    input_matrix = np.random.rand(10, 10)
+
+    matrix = DataMatrix(pd.DataFrame(data=input_matrix))
+
+    assert matrix.get_scaling_factor(event) == np.sqrt(10 / 4.0)
+
+
+@pytest.mark.parametrize(
+    "threshold,expected_result", [(0.0, 1), (0.83, 2), (0.90, 3), (0.95, 4), (0.99, 6)]
+)
+def test_get_nr_primary_components(threshold, expected_result):
+    np.random.seed(123)
+    input_matrix = np.random.rand(10, 10)
+    components, _ = DataMatrix._get_nr_primary_components(input_matrix, threshold)
+    assert components == expected_result
+
+
+def test_std_normalization():
+    input_matrix = pd.DataFrame(np.ones((3, 3)))
+    input_matrix.loc["OBS"] = np.ones(3)
+    input_matrix.loc["STD"] = np.ones(3) * 0.1
+    expected_matrix = [[10.0, 10.0, 10.0], [10.0, 10.0, 10.0], [10.0, 10.0, 10.0]]
+    matrix = DataMatrix(pd.concat({"A_KEY": input_matrix}, axis=1))
+    result = matrix.std_normalization(["A_KEY"])
+    assert (result.loc[[0, 1, 2]].values == expected_matrix).all()

--- a/tests/jobs/correlated_observations_scaling/unit/test_scaling_job.py
+++ b/tests/jobs/correlated_observations_scaling/unit/test_scaling_job.py
@@ -1,190 +1,10 @@
-import os
-import shutil
-from collections import namedtuple
-from copy import deepcopy
-
-import configsuite
 import numpy as np
 import pandas as pd
 import pytest
-from res.enkf import EnKFMain, ResConfig
 
 from ert_data import measured
-from semeio.jobs.correlated_observations_scaling import (
-    job,
-    job_config,
-    scaled_matrix,
-    validator,
-)
-from tests.jobs.correlated_observations_scaling.conftest import TEST_DATA_DIR
-
-
-@pytest.fixture()
-def setup_tmpdir(tmpdir):
-    cwd = os.getcwd()
-    tmpdir.chdir()
-    yield
-    os.chdir(cwd)
-
-
-def get_config(index_list_calc=None, index_list_update=None):
-    schema = job_config.build_schema()
-    default_values = job_config.get_default_values()
-    config = {
-        "UPDATE_KEYS": {"keys": [{"key": "POLY_OBS"}]},
-        "CALCULATE_KEYS": {"keys": [{"key": "POLY_OBS"}]},
-    }
-
-    if index_list_update:
-        config["UPDATE_KEYS"]["keys"][0].update({"index": index_list_update})
-    if index_list_calc:
-        config["CALCULATE_KEYS"]["keys"][0].update({"index": index_list_calc})
-
-    return configsuite.ConfigSuite(config, schema, layers=(default_values,)).snapshot
-
-
-@pytest.mark.skipif(TEST_DATA_DIR is None, reason="no libres test-data")
-@pytest.mark.usefixtures("setup_ert")
-def test_create_observation_vectors(setup_ert):
-
-    valid_config_data = {
-        "CALCULATE_KEYS": {"keys": [{"key": "WPR_DIFF_1"}]},
-        "UPDATE_KEYS": {"keys": [{"key": "WPR_DIFF_1"}]},
-    }
-    config = configsuite.ConfigSuite(valid_config_data, job_config.build_schema())
-
-    res_config = setup_ert
-    ert = EnKFMain(res_config)
-    obs = ert.getObservations()
-
-    new_events = job._create_active_lists(obs, config.snapshot.UPDATE_KEYS.keys)
-
-    keys = [event.key for event in new_events]
-
-    assert "WPR_DIFF_1" in keys
-    assert "SNAKE_OIL_WPR_DIFF" not in keys
-
-
-@pytest.mark.parametrize(
-    "valid_input",
-    [
-        "0,1,2-5",
-        [0, 1, "2-5"],
-        [0, 1, 2, 3, 4, 5],
-        [0, 1, "2-3", "4-5"],
-        "0-5",
-        "0-1,2,3-5",
-        ["0,1,2-5"],
-    ],
-)
-def test_to_int_list(valid_input):
-    expected_result = list(range(6))
-    assert job_config._to_int_list(valid_input) == expected_result
-
-
-@pytest.mark.parametrize(
-    "test_input,expected_result", [(-1, False), (0, True), (1, True)]
-)
-def test_min_value(test_input, expected_result):
-    assert job_config._min_value(test_input).__bool__() == expected_result
-
-
-def test_expand_input_no_modification():
-
-    expected_result = {
-        "UPDATE_KEYS": {"keys": [{"key": "key_4"}, {"key": "key_5"}, {"key": "key_6"}]},
-        "CALCULATE_KEYS": {
-            "keys": [{"key": "key_1"}, {"key": "key_2"}, {"key": "key_3"}],
-            "threshold": 1.0,
-        },
-    }
-
-    assert job_config._expand_input(deepcopy(expected_result)) == expected_result
-
-
-def test_expand_input_modification():
-    keys = [{"key": "key_1"}, {"key": "key_2"}, {"key": "key_3"}]
-    test_input = {"CALCULATE_KEYS": {"keys": keys, "threshold": 1.0}}
-
-    expected_results = deepcopy(test_input)
-    expected_results["UPDATE_KEYS"] = {"keys": keys}
-
-    assert job_config._expand_input(test_input) == expected_results
-
-
-def test_config_setup():
-
-    valid_config_data = {
-        "CALCULATE_KEYS": {"keys": [{"key": "first_key"}, {"key": "second_key"}]}
-    }
-
-    schema = job_config.build_schema()
-    config = configsuite.ConfigSuite(valid_config_data, schema)
-    assert config.valid
-
-    valid_config_data = {
-        "CALCULATE_KEYS": {"keys": [{"key": "first_key"}, {"key": "second_key"}]},
-        "UPDATE_KEYS": {"keys": [{"index": [1, 2, 3], "key": "first_key"}]},
-    }
-
-    schema = job_config.build_schema()
-    config = configsuite.ConfigSuite(valid_config_data, schema)
-    assert config.valid
-
-    invalid_too_short_index_list = {
-        "UPDATE_KEYS": {"keys": [{"index": "1", "key": ["a_key"]}]}
-    }
-
-    config = configsuite.ConfigSuite(invalid_too_short_index_list, schema)
-    assert not config.valid
-
-    invalid_missing_required_keyword = {
-        "CALCULATE_KEYS": {"keys": [{"key": "a_key"}]},
-        "UPDATE_KEYS": {"index": "1-5"},
-    }
-
-    config = configsuite.ConfigSuite(invalid_missing_required_keyword, schema)
-    assert not config.valid
-
-    invalid_negative_index = {
-        "CALCULATE_KEYS": {"keys": [{"key": "first_key"}, {"key": "second_key"}]},
-        "UPDATE_KEYS": {"keys": [{"index": [-1, 2, 3], "key": "first_key"}]},
-    }
-
-    schema = job_config.build_schema()
-    config = configsuite.ConfigSuite(invalid_negative_index, schema)
-    assert not config.valid
-
-
-def test_get_scaling_factor():
-    new_event = namedtuple("named_dict", ["keys", "threshold"])
-    event = new_event(["one_random_key"], 0.95)
-    np.random.seed(123)
-    input_matrix = np.random.rand(10, 10)
-
-    matrix = scaled_matrix.DataMatrix(pd.DataFrame(data=input_matrix))
-
-    assert matrix.get_scaling_factor(event) == np.sqrt(10 / 4.0)
-
-
-@pytest.mark.parametrize(
-    "threshold,expected_result", [(0.0, 1), (0.83, 2), (0.90, 3), (0.95, 4), (0.99, 6)]
-)
-def test_get_nr_primary_components(threshold, expected_result):
-    np.random.seed(123)
-    input_matrix = np.random.rand(10, 10)
-    matrix = scaled_matrix.DataMatrix
-    assert matrix._get_nr_primary_components(input_matrix, threshold) == expected_result
-
-
-def test_std_normalization():
-    input_matrix = pd.DataFrame(np.ones((3, 3)))
-    input_matrix.loc["OBS"] = np.ones(3)
-    input_matrix.loc["STD"] = np.ones(3) * 0.1
-    expected_matrix = [[10.0, 10.0, 10.0], [10.0, 10.0, 10.0], [10.0, 10.0, 10.0]]
-    matrix = scaled_matrix.DataMatrix(pd.concat({"A_KEY": input_matrix}, axis=1))
-    result = matrix.std_normalization(["A_KEY"])
-    assert (result.loc[[0, 1, 2]].values == expected_matrix).all()
+from semeio.jobs.correlated_observations_scaling.job import ScalingJob
+from semeio.jobs.correlated_observations_scaling.exceptions import ValidationError
 
 
 def test_filter_on_column_index():
@@ -202,135 +22,54 @@ def test_filter_on_column_index():
 
 
 @pytest.mark.parametrize(
-    "matching_keys,entry,expected_result",
+    "calc_key,app_key,obs_keys,obs_with_data,expect_valid,errors",
     [
-        (["a_key"], {"key": "a_*"}, [{"key": "a_key"}]),
-        (["a_key", "b_key"], {"key": "*key"}, [{"key": "a_key"}, {"key": "b_key"}]),
+        ("KEY_1", "KEY_1", ["KEY_1"], ["KEY_1"], True, []),
+        ("KEY_1", "KEY_1", ["KEY_1", "KEY_2"], ["KEY_1"], True, []),
         (
-            ["a_key"],
-            {"key": "a_*", "index": [1, 2]},
-            [{"key": "a_key", "index": [1, 2]}],
+            "KEY_1",
+            "KEY_1",
+            ["KEY_1", "KEY_2"],
+            ["KEY_2"],
+            False,
+            ["Key: KEY_1 has no data"],
         ),
+        (
+            "not_in_list",
+            "KEY_1",
+            ["KEY_1"],
+            ["KEY_1"],
+            False,
+            [
+                "Update key: KEY_1 missing from calculate keys: ['not_in_list']",
+                "Key: not_in_list has no observations",
+                "Key: not_in_list has no data",
+            ],
+        ),
+        (
+            "KEY_1",
+            "not_in_list",
+            ["KEY_1"],
+            ["KEY_1"],
+            False,
+            ["Update key: not_in_list missing from calculate keys: ['KEY_1']"],
+        ),
+        ("KEY_1", "KEY_1", [], ["KEY_1"], False, ["Key: KEY_1 has no observations"]),
+        ("KEY_1", "KEY_1", ["KEY_1"], [], False, ["Key: KEY_1 has no data"]),
     ],
 )
-def test_wildcard_to_dict_list(matching_keys, entry, expected_result):
-    assert job._wildcard_to_dict_list(matching_keys, entry) == expected_result
-
-
-def test_find_and_expand_wildcards():
-    expected_dict = {
-        "ANOTHER_KEY": "something",
-        "CALCULATE_KEYS": {
-            "keys": [
-                {"key": "WOPR_OP1_108"},
-                {"key": "WOPR_OP1_144"},
-                {"key": "WOPR_OP1_190"},
-                {"key": "WOPR_OP1_9"},
-                {"key": "WOPR_OP1_36"},
-                {"key": "WOPR_OP1_72"},
-                {"key": "FOPR"},
-            ]
-        },
-        "UPDATE_KEYS": {
-            "keys": [
-                {"key": "WOPR_OP1_108"},
-                {"key": "WOPR_OP1_144"},
-                {"key": "WOPR_OP1_190"},
-                {"key": "FOPR"},
-            ]
-        },
+@pytest.mark.usefixtures("setup_tmpdir")
+def test_valid_job(calc_key, app_key, obs_keys, obs_with_data, expect_valid, errors):
+    user_config_dict = {
+        "CALCULATE_KEYS": {"keys": [{"key": calc_key}]},
+        "UPDATE_KEYS": {"keys": [{"key": app_key}]},
     }
-
-    user_config = {
-        "ANOTHER_KEY": "something",
-        "CALCULATE_KEYS": {"keys": [{"key": "WOPR_*"}, {"key": "FOPR"}]},
-        "UPDATE_KEYS": {"keys": [{"key": "WOPR_OP1_1*"}, {"key": "FOPR"}]},
-    }
-
-    observation_list = [
-        "WOPR_OP1_108",
-        "WOPR_OP1_144",
-        "WOPR_OP1_190",
-        "WOPR_OP1_9",
-        "WOPR_OP1_36",
-        "WOPR_OP1_72",
-        "FOPR",
-    ]
-
-    result_dict = job._find_and_expand_wildcards(observation_list, user_config)
-
-    assert result_dict == expected_dict
-
-
-@pytest.mark.skipif(TEST_DATA_DIR is None, reason="no libres test-data")
-@pytest.mark.usefixtures("setup_tmpdir")
-def test_add_observation_vectors():
-
-    valid_config_data = {"UPDATE_KEYS": {"keys": [{"key": "WOPR_OP1_108"}]}}
-
-    schema = job_config.build_schema()
-    config = configsuite.ConfigSuite(valid_config_data, schema)
-
-    test_data_dir = os.path.join(TEST_DATA_DIR, "local", "snake_oil_field")
-
-    shutil.copytree(test_data_dir, "test_data")
-    os.chdir(os.path.join("test_data"))
-
-    res_config = ResConfig("snake_oil.ert")
-
-    ert = EnKFMain(res_config)
-
-    obs = ert.getObservations()
-
-    new_events = job._create_active_lists(obs, config.snapshot.UPDATE_KEYS.keys)
-
-    keys = [event.key for event in new_events]
-
-    assert "WOPR_OP1_108" in keys
-    assert "WOPR_OP1_144" not in keys
-
-
-@pytest.mark.skipif(TEST_DATA_DIR is None, reason="no libres test-data")
-@pytest.mark.usefixtures("setup_tmpdir")
-def test_validate_failed_realizations():
-    """
-    Config has several failed realisations
-    """
-    test_data_dir = os.path.join(TEST_DATA_DIR, "local", "custom_kw")
-    shutil.copytree(test_data_dir, "test_data")
-    os.chdir(os.path.join("test_data"))
-
-    res_config = ResConfig("mini_fail_config")
-    ert = EnKFMain(res_config)
-    observations = ert.getObservations()
-
-    result = job.keys_with_data(
-        observations,
-        ["GEN_PERLIN_1"],
-        ert.getEnsembleSize(),
-        ert.getEnkfFsManager().getCurrentFileSystem(),
-    )
-    assert result == ["GEN_PERLIN_1"]
-
-
-@pytest.mark.skipif(TEST_DATA_DIR is None, reason="no libres test-data")
-@pytest.mark.usefixtures("setup_tmpdir")
-def test_validate_no_realizations():
-    """
-    Ensamble has not run
-    """
-    test_data_dir = os.path.join(TEST_DATA_DIR, "local", "poly_normal")
-    shutil.copytree(test_data_dir, "test_data")
-    os.chdir(os.path.join("test_data"))
-
-    res_config = ResConfig("poly.ert")
-    ert = EnKFMain(res_config)
-    observations = ert.getObservations()
-
-    result = job.keys_with_data(
-        observations,
-        ["POLY_OBS"],
-        ert.getEnsembleSize(),
-        ert.getEnkfFsManager().getCurrentFileSystem(),
-    )
-    assert result == []
+    if expect_valid:
+        try:
+            ScalingJob(obs_keys, [], obs_with_data, user_config_dict)
+        except ValidationError as e:
+            pytest.fail("unexpectedly raised ValidationError: {}".format(e))
+    else:
+        with pytest.raises(ValidationError) as exc_info:
+            ScalingJob(obs_keys, [], obs_with_data, user_config_dict)
+        assert exc_info.value.errors == errors

--- a/tests/jobs/correlated_observations_scaling/unit/test_validator.py
+++ b/tests/jobs/correlated_observations_scaling/unit/test_validator.py
@@ -1,4 +1,5 @@
 import sys
+
 import pytest
 
 from semeio.jobs.correlated_observations_scaling import validator
@@ -21,7 +22,7 @@ else:
 def test_has_keys(test_input, expected_result):
     obs = ["POLY_OBS"]
     msg = "fail_message"
-    assert len(validator._has_keys(obs, test_input, msg)) == expected_result
+    assert len(validator.has_keys(obs, test_input, msg)) == expected_result
 
 
 @pytest.mark.parametrize(
@@ -30,7 +31,7 @@ def test_has_keys(test_input, expected_result):
 def test_is_subset_valid(input_list, result_list):
     example_list = ["a", "b", "c"]
 
-    assert validator._is_subset(example_list, input_list) == result_list
+    assert validator.is_subset(example_list, input_list) == result_list
 
 
 @pytest.mark.parametrize(
@@ -39,31 +40,4 @@ def test_is_subset_valid(input_list, result_list):
 def test_is_subset_invalid(input_list, list_length):
     example_list = ["a", "b", "c"]
 
-    assert len(validator._is_subset(example_list, input_list)) == list_length
-
-
-@pytest.mark.parametrize(
-    "calc_key,app_key,obs_list,data_list,expected_result",
-    [
-        ("KEY_1", "KEY_1", ["KEY_1"], ["KEY_1"], True),
-        ("KEY_1", "KEY_1", ["KEY_1", "KEY_2"], ["KEY_1"], True),
-        ("KEY_1", "KEY_1", ["KEY_1", "KEY_2"], ["KEY_2"], False),
-        ("not_in_list", "KEY_1", ["KEY_1"], ["KEY_1"], False),
-        ("KEY_1", "not_in_list", ["KEY_1"], ["KEY_1"], False),
-        ("KEY_1", "KEY_1", [], ["KEY_1"], False),
-        ("KEY_1", "KEY_1", ["KEY_1"], [], False),
-    ],
-)
-def test_valid_job(calc_key, app_key, obs_list, data_list, expected_result):
-
-    mock_entry_1 = Mock()
-    mock_entry_1.key = calc_key
-
-    mock_entry_2 = Mock()
-    mock_entry_2.key = app_key
-
-    user_config = Mock()
-    user_config.snapshot.CALCULATE_KEYS.keys = [mock_entry_1]
-    user_config.snapshot.UPDATE_KEYS.keys = [mock_entry_2]
-
-    assert validator.valid_job(user_config, obs_list, data_list) is expected_result
+    assert len(validator.is_subset(example_list, input_list)) == list_length

--- a/tests/jobs/spearman_correlation_job/unit/test_spearman_job.py
+++ b/tests/jobs/spearman_correlation_job/unit/test_spearman_job.py
@@ -1,48 +1,7 @@
 # -*- coding: utf-8 -*-
-import sys
-
 import pytest
+
 from semeio.jobs.spearman_correlation_job import job as spearman
-
-if sys.version_info >= (3, 3):
-    from unittest.mock import Mock
-else:
-    from mock import Mock
-
-
-@pytest.mark.parametrize(
-    "test_input",
-    [
-        ([{"CALCULATE_KEYS": {"keys": [{"key": "KEY_1", "index": [1]}]}}]),
-        ([{"CALCULATE_KEYS": {"keys": [{"key": "KEY_1", "index": [1, 2]}]}}]),
-        (
-            [
-                {
-                    "CALCULATE_KEYS": {
-                        "keys": [
-                            {"key": "KEY_1", "index": [1, 2]},
-                            {"key": "KEY_2", "index": [1, 2]},
-                        ]
-                    }
-                }
-            ]
-        ),
-        (
-            [
-                {"CALCULATE_KEYS": {"keys": [{"key": "KEY_1", "index": [1, 2]}]}},
-                {"CALCULATE_KEYS": {"keys": [{"key": "KEY_2", "index": [5, 6]}]}},
-            ]
-        ),
-    ],
-)
-def test_run_scaling(test_input, monkeypatch):
-    facade = Mock()
-    scal_job = Mock()
-    monkeypatch.setattr(spearman, "scaling_job", scal_job)
-    spearman._run_scaling(facade, test_input)
-    for input_config in test_input:
-        assert scal_job.any_call(input_config)
-    assert scal_job.call_count == len(test_input)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Creates an obs_util package, for a lack of a better name. Also splits up test_scaling_job into more fitting constituents.
- Stamps out facade from both COS and SC. This simplifies testing, but also moves both jobs to the same abstraction layer which also eases interoperability.
- SC is now more of a config-generator, and the code reflects this. And SC uses the CorrelatedObservationsScalingJob, which improves encapsulation (SC knows less about COS).
- Tests are mainly moved around. I've removed one test which was not providing any value (that I saw) `test_run_scaling`. Happy to reintroduce, but this path is already well-tested.