### PR TITLE
Fail if CALC key wild cards produce empty config

### DIFF
--- a/semeio/jobs/correlated_observations_scaling/exceptions.py
+++ b/semeio/jobs/correlated_observations_scaling/exceptions.py
@@ -6,3 +6,10 @@ class ValidationError(ValueError):
     def __init__(self, message, errors):
         super(ValidationError, self).__init__(message)
         self.errors = errors
+        self.message = message
+
+    def __str__(self):
+        msg = "{}\n".format(self.message)
+        for error in self.errors:
+            msg += "\t{}".format(error)
+        return msg

--- a/semeio/jobs/scripts/correlated_observations_scaling.py
+++ b/semeio/jobs/scripts/correlated_observations_scaling.py
@@ -5,7 +5,6 @@ import yaml
 from ert_data.measured import MeasuredData
 from ert_shared.libres_facade import LibresFacade
 from res.enkf import ErtScript
-from semeio.jobs.correlated_observations_scaling.exceptions import ValidationError
 from semeio.jobs.correlated_observations_scaling.job import ScalingJob
 from semeio.jobs.correlated_observations_scaling.obs_utils import keys_with_data
 
@@ -23,14 +22,7 @@ class CorrelatedObservationsScalingJob(ErtScript):
         )
 
         for config in user_config:
-            try:
-                job = ScalingJob(obs_keys, obs, obs_with_data, config)
-            except ValidationError as validation_error:
-                print(str(validation_error))
-                for error in validation_error.errors:
-                    print("\t{}".format(error))
-                continue
-
+            job = ScalingJob(obs_keys, obs, obs_with_data, config)
             measured_data = MeasuredData(
                 facade, job.get_calc_keys(), job.get_index_lists()
             )

--- a/tests/jobs/correlated_observations_scaling/test_integration.py
+++ b/tests/jobs/correlated_observations_scaling/test_integration.py
@@ -4,8 +4,8 @@ import shutil
 import numpy as np
 import pytest
 import yaml
-
 from res.enkf import EnKFMain, ResConfig
+
 from semeio.jobs.scripts.correlated_observations_scaling import (
     CorrelatedObservationsScalingJob,
 )


### PR DESCRIPTION
The empty CALCULATE_KEYS config has special meaning: it means use all
keys. This is most likely not what the user wants. No matches for a
wildcard has to be assumed to be a user error, and the scaling job
should therefore fail.