### PR TITLE
Add simple report function

### DIFF
--- a/semeio/reporter/__init__.py
+++ b/semeio/reporter/__init__.py
@@ -1,1 +1,1 @@
-from .reporter import report
+from semeio.reporter.reporter import report

--- a/semeio/reporter/__init__.py
+++ b/semeio/reporter/__init__.py
@@ -1,0 +1,1 @@
+from .reporter import report

--- a/semeio/reporter/reporter.py
+++ b/semeio/reporter/reporter.py
@@ -1,0 +1,29 @@
+from .serialize_numpy import serialize_numpy
+from .serialize_json import serialize_json
+
+
+class Reporter(object):
+    _serializers = [serialize_numpy, serialize_json]
+
+    def __init__(self):
+        pass
+
+    def report(self, key, val):
+        if not isinstance(key, str):
+            raise TypeError("Report key must be of type str")
+        if key == "" or "/" in key:
+            raise ValueError("Invalid report key")
+
+        for ser in self._serializers:
+            if ser(key, val):
+                return
+        raise TypeError(
+            "Reporter cannot serialize values of type '{}'".format(type(val).__name__)
+        )
+
+
+_reporter = Reporter()
+
+
+def report(key, val):
+    _reporter.report(key, val)

--- a/semeio/reporter/reporter.py
+++ b/semeio/reporter/reporter.py
@@ -1,9 +1,12 @@
-from .serialize_numpy import serialize_numpy
-from .serialize_json import serialize_json
+import re
+
+from semeio.reporter.serialize_numpy import serialize_numpy
+from semeio.reporter.serialize_json import serialize_json
 
 
 class Reporter(object):
     _serializers = [serialize_numpy, serialize_json]
+    _valid_key = re.compile("^[0-9a-zA-Z-_+.]+$")
 
     def __init__(self):
         pass
@@ -11,8 +14,8 @@ class Reporter(object):
     def report(self, key, val):
         if not isinstance(key, str):
             raise TypeError("Report key must be of type str")
-        if key == "" or "/" in key:
-            raise ValueError("Invalid report key")
+        if key.match(self._valid_key):
+            raise ValueError("Report key {} malformed: May only contain alphanumerics, '_', '-', '+', '.'", repr(key))
 
         for ser in self._serializers:
             if ser(key, val):

--- a/semeio/reporter/serialize_json.py
+++ b/semeio/reporter/serialize_json.py
@@ -1,0 +1,10 @@
+import json
+
+
+def serialize_json(key, val):
+    try:
+        with open("{}.json".format(key), "w") as f:
+            json.dump(val, f)
+    except:
+        return False
+    return True

--- a/semeio/reporter/serialize_json.py
+++ b/semeio/reporter/serialize_json.py
@@ -5,6 +5,10 @@ def serialize_json(key, val):
     try:
         with open("{}.json".format(key), "w") as f:
             json.dump(val, f)
-    except:
+    except OverflowError:
+        # Happens when there is a cycle
+        return False
+    except TypeError:
+        # Unserialisable type
         return False
     return True

--- a/semeio/reporter/serialize_numpy.py
+++ b/semeio/reporter/serialize_numpy.py
@@ -1,0 +1,10 @@
+import numpy as np
+import pandas as pd
+
+
+def serialize_numpy(key, val):
+    if not isinstance(val, np.ndarray):
+        return False
+
+    pd.DataFrame(val).to_csv("{}.csv".format(key), header=False, index=False)
+    return True

--- a/tests/reporter/test_reporter.py
+++ b/tests/reporter/test_reporter.py
@@ -1,0 +1,50 @@
+import pytest
+import numpy as np
+from semeio.reporter import report
+
+
+def test_empty_key(tmpdir):
+    with tmpdir.as_cwd(), pytest.raises(ValueError):
+        report("", 0)
+
+
+def test_key_is_path(tmpdir):
+    with tmpdir.as_cwd(), pytest.raises(ValueError):
+        report("/etc/motd", 0)
+
+
+def test_key_invalid_type(tmpdir):
+    with tmpdir.as_cwd(), pytest.raises(TypeError):
+        report(b"hi", 0)
+
+
+def test_key(tmpdir):
+    with tmpdir.as_cwd():
+        report("hi", 0)
+        with open("hi.json") as f:
+            assert f.read() == "0"
+
+
+def test_json(tmpdir):
+    data_dict = {"foo": "bar", "baz": [{"key": 1}, {"nøkkel": 2}]}
+    data_str = '{"foo": "bar", "baz": [{"key": 1}, {"n\\u00f8kkel": 2}]}'
+
+    with tmpdir.as_cwd():
+        report("my_data", data_dict)
+        with open("my_data.json") as f:
+            assert f.read() == data_str
+
+
+def test_numpy(tmpdir):
+    mat = np.matrix([[1, 2, 3], [float("inf"), 3.14, -1]])
+    str_ = "1.0,2.0,3.0\ninf,3.14,-1.0\n"
+
+    with tmpdir.as_cwd():
+        report("my_mat", mat)
+        with open("my_mat.csv") as f:
+            assert f.read() == str_
+
+
+def test_invalid(tmpdir):
+    with tmpdir.as_cwd(), pytest.raises(TypeError):
+        report("fail", tmpdir)

--- a/tests/reporter/test_serialize_json.py
+++ b/tests/reporter/test_serialize_json.py
@@ -1,0 +1,37 @@
+from semeio.reporter.serialize_json import serialize_json
+
+
+def test_simple(tmpdir):
+    with tmpdir.as_cwd():
+        assert serialize_json("test", "Test")
+        with open("test.json") as f:
+            assert f.read() == '"Test"'
+
+
+def test_complex(tmpdir):
+    data_dict = {"foo": "bar", "baz": [{"key": 1}, {"nøkkel": 2}]}
+    data_str = '{"foo": "bar", "baz": [{"key": 1}, {"n\\u00f8kkel": 2}]}'
+
+    with tmpdir.as_cwd():
+        assert serialize_json("complex", data_dict)
+        with open("complex.json") as f:
+            assert f.read() == data_str
+
+
+def test_simple_fail(tmpdir):
+    # tmpdir object is not JSON-serialisable
+    with tmpdir.as_cwd():
+        assert not serialize_json("test", tmpdir)
+
+
+def test_complex_fail(tmpdir):
+    data_dict = {"foo": "bar", "baz": [{"key": serialize_json}, {"nøkkel": 2}]}
+    with tmpdir.as_cwd():
+        assert not serialize_json("test", data_dict)
+
+
+def test_recursive_fail(tmpdir):
+    data = {}
+    data["data"] = data
+    with tmpdir.as_cwd():
+        assert not serialize_json("rec", data)

--- a/tests/reporter/test_serialize_numpy.py
+++ b/tests/reporter/test_serialize_numpy.py
@@ -1,0 +1,27 @@
+from semeio.reporter.serialize_numpy import serialize_numpy
+import numpy as np
+
+
+def test_invalid(tmpdir):
+    with tmpdir.as_cwd():
+        assert not serialize_numpy("try", 0)
+
+
+def test_array(tmpdir):
+    arr = np.array([float("inf"), 3.14, -1])
+    str_ = "inf\n3.14\n-1.0\n"
+
+    with tmpdir.as_cwd():
+        assert serialize_numpy("arr", arr)
+        with open("arr.csv") as f:
+            assert f.read() == str_
+
+
+def test_matrix(tmpdir):
+    mat = np.matrix([[1, 2, 3], [float("inf"), 3.14, -1]])
+    str_ = "1.0,2.0,3.0\ninf,3.14,-1.0\n"
+
+    with tmpdir.as_cwd():
+        assert serialize_numpy("mat", mat)
+        with open("mat.csv") as f:
+            assert f.read() == str_


### PR DESCRIPTION
This PR provides a `report(key, val)` function that creates a file with `key` as basename and appropriate extension for the type of `val`. If `val` is a numpy array then it is written to cwd as `{key}.csv` using pandas. If `val` is representable as JSON, then a `{key}.json` is created.

This is a dead stupid change, but it can serve as foundation for future work. I believe having two APIs for reporting is necessary:
1. Internal Python jobs that use `ErtScript` would need to have their own `Reporter` object with added context about the workflow (ie. unique identifier). This object must be created and managed by libres.
2. External Python jobs can `from semeio.reporter import report` and then use it as is. This would behave like `logging.info`, where it is initialised with sensible defaults, but you can override the behaviour. For example, on first `report` invocation, a connection to ERT will be attempted, but unit tests may change the report handler and mock the connection.

I do not think this PR belongs in `semeio`, however. It should be in its own repository or libres.

---
## Logger
POSIX mandates only two output streams `stdout` and `stderr`, thus Python's logging stuff isn't visible from the outside world. For external Python workflow we should provide a convenience function that installs the necessary handlers that `report` stuff to ERT. Thus, there can be three types of external workflows:
1. Compliant: ERT sees both `stdout`, `stderr` and a nicely formatted `logging`.
2. Non-compliant: ERT sees only `stdout`, `stderr`. Python's `logging` writes to `stdout` by default.
3. Very non-compliant: Python's `logging` was told to write to `stdout.log`. ERT sees nothing. We tell our users to please stop.

The logger stream can be smarter than a simple byte stream. We could, for example, mandate each message is a single UTF-8 line, with a timestamp and log level. Thus it'd be possible to show dates for each line and highlight warnings in the GUI.

I've prototyped streaming data via ZeroMQ and similar reporter, and wouldn't be difficult to do with a bit more infrastructure:
https://github.com/equinor/ert-msgbus/blob/fc867325e1acb607094890e1cea0e9285dead64c/ert_msgbus/service/reporter.py#L9
https://github.com/equinor/ert-msgbus/blob/fc867325e1acb607094890e1cea0e9285dead64c/ert_msgbus/service/message.py#L27

---
## Yet another call to use UNIX sockets instead of TCP in the future for external workflows
I'll beat this dead horse some more. However the communication channel will look like, I think it's important that our first attempt will be to use UNIX sockets instead of trying to do TCP/HTTP:
1. It is trivial to add security so that only the current user's processes can use this channel. No need for authentication, SSL or crypto.
2. SSH can forward UNIX sockets: https://medium.com/@dperny/forwarding-the-docker-socket-over-ssh-e6567cfab160
3. It is more performant than TCP since it avoids the entire network stack

ZeroMQ supports both in-process, unix and tcp sockets. If we choose to go with ZeroMQ then this is trivial. But if we choose to write our own, I think UNIX is the correct decision.