### PR TITLE
Pin pylint and pytest

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,5 @@
-pytest
+pytest==5.4.3; python_version>="3.6"  # Fixed in https://github.com/pytest-dev/pytest/pull/7565
+pytest; python_version<="2.7"
 mock
 zipp<2; python_version<='2.7'
 configparser<5; python_version<='2.7'

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands = python -m pytest tests
 
 [testenv:style]
 deps = pre-commit
-       pylint
+       pylint==2.5.3 # Fixed in https://github.com/pytest-dev/pytest/pull/7565
        black
        flake8
        {[testenv]deps}


### PR DESCRIPTION
The pylint not-callable error on pytest.mark.parametrize(...)
error is a recurring issue for pytest, but should be fixed now:
pytest-dev/pytest#7565

Did not make it in the 6.0.0 release, pin for now.