### PR TITLE
Persist all reported data

### DIFF
--- a/semeio/communication/reporter.py
+++ b/semeio/communication/reporter.py
@@ -16,8 +16,16 @@ class FileReporter(object):
 
     def publish(self, namespace, data):
         output_file = self._prepare_output_file(namespace) + ".json"
+
+        if os.path.exists(output_file):
+            with open(output_file) as f:
+                all_data = json.load(f)
+        else:
+            all_data = []
+
+        all_data.append(data)
         with open(output_file, "w") as f:
-            json.dump(data, f)
+            json.dump(all_data, f)
 
     def publish_msg(self, namespace, msg):
         fmt = "{}\n"

--- a/tests/communication/test_integration.py
+++ b/tests/communication/test_integration.py
@@ -38,7 +38,7 @@ def test_semeio_script_integration(tmpdir):
     # Assert that data was published correctly
     with open("storage/reports/TestWorkflowJob/test_data.json") as f:
         reported_data = json.load(f)
-    assert list(range(10)) == reported_data
+    assert [list(range(10))] == reported_data
 
     # Assert that logs were forwarded correctly
     log_file = os.path.join("storage/reports/TestWorkflowJob/", SEMEIOSCRIPT_LOG_FILE)

--- a/tests/communication/unit/test_file_reporter.py
+++ b/tests/communication/unit/test_file_reporter.py
@@ -129,7 +129,7 @@ def test_file_reporter_publish_valid_json(data, tmpdir):
     with open(namespace + ".json") as f:
         loaded_data = json.load(f)
 
-    assert loaded_data == data
+    assert loaded_data == [data]
 
 
 def test_file_reporter_publish_invalid_json(tmpdir):
@@ -148,13 +148,14 @@ def test_file_reporter_publish_multiple_json(tmpdir):
     namespace = "some_data"
     reporter = FileReporter(os.getcwd())
 
-    for data in [0, [0, 12], "Dear JSON"]:
-        reporter.publish(namespace, data)
+    data = [0, [0, 12], "Dear JSON"]
+    for idx, data_elem in enumerate(data):
+        reporter.publish(namespace, data_elem)
 
         with open(namespace + ".json") as f:
             loaded_data = json.load(f)
 
-        assert loaded_data == data
+        assert loaded_data == data[: idx + 1]
 
 
 def test_file_reporter_publish_multiple_namespaces(tmpdir):
@@ -172,11 +173,11 @@ def test_file_reporter_publish_multiple_namespaces(tmpdir):
 
     with open(namespace1 + ".json") as f:
         loaded_data1 = json.load(f)
-    assert loaded_data1 == data1
+    assert loaded_data1 == [data1]
 
     with open(namespace2 + ".json") as f:
         loaded_data2 = json.load(f)
-    assert loaded_data2 == data2
+    assert loaded_data2 == [data2]
 
 
 @pytest.mark.parametrize(
@@ -187,7 +188,7 @@ def test_file_reporter_publish_multiple_namespaces(tmpdir):
         )
     ),
 )
-def test_file_reporter_publisg_output_location(folder, namespace, tmpdir):
+def test_file_reporter_publish_output_location(folder, namespace, tmpdir):
     tmpdir.chdir()
     reporter = FileReporter(os.path.join(os.getcwd(), folder))
 
@@ -198,7 +199,7 @@ def test_file_reporter_publisg_output_location(folder, namespace, tmpdir):
 
     with open(expected_output_file) as f:
         loaded_data = json.load(f)
-    assert data == loaded_data
+    assert [data] == loaded_data
 
 
 @pytest.mark.parametrize(

--- a/tests/communication/unit/test_semeio_script.py
+++ b/tests/communication/unit/test_semeio_script.py
@@ -38,7 +38,7 @@ def test_semeio_script_publish(tmpdir):
     with open(expected_outputfile) as f:
         published_data = json.load(f)
 
-    assert data == published_data
+    assert [data] == published_data
 
 
 def test_semeio_script_logging(tmpdir):

--- a/tests/jobs/correlated_observations_scaling/test_integration.py
+++ b/tests/jobs/correlated_observations_scaling/test_integration.py
@@ -149,7 +149,10 @@ def test_main_entry_point_gen_data():
     )
     # Assert that data was published correctly
     with open(svd_file) as f:
-        reported_svd = json.load(f)
+        svd_reports = json.load(f)
+        assert len(svd_reports) == 2
+
+        reported_svd = svd_reports[1]
         assert reported_svd == pytest.approx(
             (6.531760256452532, 2.0045135017540487, 1.1768827000026516,), 0.1
         )
@@ -159,7 +162,10 @@ def test_main_entry_point_gen_data():
         "CorrelatedObservationsScalingJob/scale_factor.json"
     )
     with open(scale_file) as f:
-        reported_scalefactor = json.load(f)
+        scalefactor_reports = json.load(f)
+        assert len(scalefactor_reports) == 2
+
+        reported_scalefactor = scalefactor_reports[1]
         assert reported_scalefactor == pytest.approx(1.224744871391589, 0.1)
 
 

--- a/tests/jobs/spearman_correlation_job/test_integration.py
+++ b/tests/jobs/spearman_correlation_job/test_integration.py
@@ -50,7 +50,10 @@ def test_main_entry_point_gen_data(monkeypatch):
         "storage/snake_oil/ensemble/reports/SpearmanCorrelationJob/clusters.json"
     )
     with open(clusters_file) as f:
-        clusters = json.load(f)
+        cluster_reports = json.load(f)
+        assert len(cluster_reports) == 1
+
+        clusters = cluster_reports[0]
         assert len(clusters.keys()) == 47
 
 
@@ -159,5 +162,8 @@ def test_main_entry_point_syn_data(monkeypatch, facade, measured_data):
     assert (expected_corr_matrix == corr_matrix.values).all()
     clusters_file = "reports/SpearmanCorrelationJob/clusters.json"
     with open(clusters_file) as f:
-        clusters = json.load(f)
+        cluster_reports = json.load(f)
+        assert len(cluster_reports) == 1
+
+        clusters = cluster_reports[0]
         assert len(clusters.keys()) == 1


### PR DESCRIPTION
Resolves #120 

This is a possible solution to the reporter overwriting previously published data, by keeping all reports of the same namespace and name within a list. As there are no guarantees on the output format of the data, and the data is to be moved to storage over time, I believe this is a non-controversial change. It is for sure not the perfect solution for the problem, but I think it is adequate until we start learning about consuming this data from a readers perspective.