### PR TITLE
Downgrade Python37 to Python36 for syntax check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       env: TOXENV=py37
     - python: 3.8
       env: TOXENV=py38
-    - python: 3.7
+    - python: 3.6
       env: TOXENV=style
       install: true
 


### PR DESCRIPTION
It seems that `pylint` is not longer compatible with python37 for some dependencies. Therefore, this PR downgrades Python37 to Python36. For reference: https://github.com/PyCQA/pylint/issues/2241