### PR TITLE
First version - ensure folder structure

### DIFF
--- a/semeio/jobs/ensure_folder_structure/__init__.py
+++ b/semeio/jobs/ensure_folder_structure/__init__.py
@@ -1,0 +1,1 @@
+from semeio.jobs.ensure_folder_structure.job import ensure_folder_structure as run

--- a/semeio/jobs/ensure_folder_structure/job.py
+++ b/semeio/jobs/ensure_folder_structure/job.py
@@ -1,0 +1,35 @@
+import logging
+import os
+
+
+def _validate_path_element(path_elem):
+    if os.path.isabs(path_elem):
+        raise ValueError(
+            "Configured structure cannot contain absolute elements."
+            "Found: {}".format(path_elem)
+        )
+    if ".." in path_elem:
+        raise ValueError(
+            "Path elements should not contain '..'."
+            "Found: {}".format(path_elem)
+        )
+
+
+def _expand_folders(folder_structure, root):
+    if folder_structure is None:
+        return [root]
+
+    folder_list = []
+    for elem, subs in folder_structure.items():
+        _validate_path_element(elem)
+        folder_list += _expand_folders(subs, os.path.join(root, elem))
+
+    return folder_list
+
+
+def ensure_folder_structure(folder_structure, root):
+    root = os.path.realpath(root)
+    folders = _expand_folders(folder_structure, root)
+    for elem in folders:
+        os.makedirs(elem, exist_ok=True)
+        logging.info("Created folder: {}".format(elem))

--- a/semeio/jobs/ensure_folder_structure/job.py
+++ b/semeio/jobs/ensure_folder_structure/job.py
@@ -10,8 +10,7 @@ def _validate_path_element(path_elem):
         )
     if ".." in path_elem:
         raise ValueError(
-            "Path elements should not contain '..'."
-            "Found: {}".format(path_elem)
+            "Path elements should not contain '..'. Found: {}".format(path_elem)
         )
 
 

--- a/semeio/jobs/ensure_folder_structure/job.py
+++ b/semeio/jobs/ensure_folder_structure/job.py
@@ -31,5 +31,6 @@ def ensure_folder_structure(folder_structure, root):
     root = os.path.realpath(root)
     folders = _expand_folders(folder_structure, root)
     for elem in folders:
-        os.makedirs(elem, exist_ok=True)
-        logging.info("Created folder: {}".format(elem))
+        if not os.path.isdir(elem):
+            os.makedirs(elem)
+            logging.info("Created folder: {}".format(elem))

--- a/semeio/jobs/scripts/ensure_folder_structure.py
+++ b/semeio/jobs/scripts/ensure_folder_structure.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+import argparse
+import yaml
+
+from semeio.jobs import ensure_folder_structure
+
+
+def _parse_arguments():
+    parser = argparse.ArgumentParser(description=(
+        """Ensures that the specified folder structure is present on disk and if not,
+        creates it.
+
+        Example:
+        a:
+          b:
+          c:
+            d:
+        e:
+        f:
+
+        Would result in three folders (a, e and f) existing in the root folder.
+        Two folders (b and c) will exist inside a. And inside c again, a single
+        folder named d will reside.
+        """
+
+    ))
+    parser.add_argument(
+        "configfile",
+        help="The folder structure configuration",
+    )
+    parser.add_argument(
+        "-r",
+        "--root",
+        dest="root",
+        default=".",
+    )
+    return parser.parse_args()
+
+
+def _load_config(configfile):
+    with open(configfile) as f:
+        return yaml.safe_load(f)
+
+
+if __name__ == "__main__":
+    args = _parse_arguments()
+    folder_structure = _load_config(args.configfile)
+    ensure_folder_structure.run(folder_structure, args.root)

--- a/semeio/jobs/scripts/ensure_folder_structure.py
+++ b/semeio/jobs/scripts/ensure_folder_structure.py
@@ -6,8 +6,9 @@ from semeio.jobs import ensure_folder_structure
 
 
 def _parse_arguments():
-    parser = argparse.ArgumentParser(description=(
-        """Ensures that the specified folder structure is present on disk and if not,
+    parser = argparse.ArgumentParser(
+        description=(
+            """Ensures that the specified folder structure is present on disk and if not,
         creates it.
 
         Example:
@@ -22,17 +23,13 @@ def _parse_arguments():
         Two folders (b and c) will exist inside a. And inside c again, a single
         folder named d will reside.
         """
-
-    ))
-    parser.add_argument(
-        "configfile",
-        help="The folder structure configuration",
+        )
     )
     parser.add_argument(
-        "-r",
-        "--root",
-        dest="root",
-        default=".",
+        "configfile", help="The folder structure configuration",
+    )
+    parser.add_argument(
+        "-r", "--root", dest="root", default=".",
     )
     return parser.parse_args()
 

--- a/tests/jobs/ensure_folder_structure/unit/test_ensure_folder_structure.py
+++ b/tests/jobs/ensure_folder_structure/unit/test_ensure_folder_structure.py
@@ -27,12 +27,7 @@ def assert_leaf_folders(folders, base="."):
 @pytest.mark.parametrize(
     ("config", "existing_folders", "expected_new_folders", "root"),
     [
-        [
-            "a:",
-            [],
-            ["a"],
-            ".",
-        ],
+        ["a:", [], ["a"], ".",],
         [
             """
               a:
@@ -50,10 +45,7 @@ def assert_leaf_folders(folders, base="."):
                 c:
             """,
             [],
-            [
-                "root/a/b",
-                "root/a/c"
-            ],
+            ["root/a/b", "root/a/c"],
             "root",
         ],
         [
@@ -89,7 +81,7 @@ def assert_leaf_folders(folders, base="."):
             ],
             ".",
         ],
-    ]
+    ],
 )
 def test_ensure_folder_structure(
     config, existing_folders, expected_new_folders, root, tmpdir,
@@ -164,12 +156,14 @@ def test_ensure_folder_structure_script(tmpdir):
     tmpdir.chdir()
 
     with open("config.yml", "w") as f:
-        f.write("""
+        f.write(
+            """
             a:
               b:
               c:
             d:
-        """)
+        """
+        )
 
     subprocess.check_call(["ensure_folder_structure.py", "config.yml"])
 

--- a/tests/jobs/ensure_folder_structure/unit/test_ensure_folder_structure.py
+++ b/tests/jobs/ensure_folder_structure/unit/test_ensure_folder_structure.py
@@ -1,0 +1,176 @@
+import os
+import pytest
+import subprocess
+import yaml
+
+from semeio.jobs import ensure_folder_structure
+
+
+def _create_folders(folders):
+    for folder in folders:
+        os.makedirs(folder)
+
+
+def assert_leaf_folders(folders, base="."):
+    base = os.path.realpath(base)
+    leaf_folders_on_disk = []
+    for root, dirs, _ in os.walk(base):
+        if len(dirs) == 0 and root != base:
+            leaf_folders_on_disk.append(root)
+
+    leaf_folders_on_disk = sorted(map(os.path.realpath, leaf_folders_on_disk))
+    folders = sorted([os.path.realpath(os.path.join(base, elem)) for elem in folders])
+
+    assert leaf_folders_on_disk == folders
+
+
+@pytest.mark.parametrize(
+    ("config", "existing_folders", "expected_new_folders", "root"),
+    [
+        [
+            "a:",
+            [],
+            ["a"],
+            ".",
+        ],
+        [
+            """
+              a:
+                b:
+                c:
+            """,
+            ["a/b"],
+            ["a/c"],
+            ".",
+        ],
+        [
+            """
+              a:
+                b:
+                c:
+            """,
+            [],
+            [
+                "root/a/b",
+                "root/a/c"
+            ],
+            "root",
+        ],
+        [
+            """
+              a:
+                b:
+                c:
+            """,
+            ["root/a/b"],
+            ["root/a/c"],
+            "root",
+        ],
+        [
+            """
+            in:
+              some_data:
+              the_secret_sauce:
+                ingredient1:
+                ingredient2:
+            config:
+            out:
+              exports:
+              storage:
+            """,
+            [],
+            [
+                "in/some_data",
+                "in/the_secret_sauce/ingredient1",
+                "in/the_secret_sauce/ingredient2",
+                "config",
+                "out/exports",
+                "out/storage",
+            ],
+            ".",
+        ],
+    ]
+)
+def test_ensure_folder_structure(
+    config, existing_folders, expected_new_folders, root, tmpdir,
+):
+    tmpdir.chdir()
+    config = yaml.safe_load(config)
+
+    _create_folders(existing_folders)
+    assert_leaf_folders(existing_folders)
+
+    ensure_folder_structure.run(config, root)
+    assert_leaf_folders(existing_folders + expected_new_folders)
+
+
+def test_ensure_folder_structure_backroot(tmpdir):
+    subdir = tmpdir.mkdir("sub")
+    subdir.chdir()
+
+    config = {"a": {"b": None, "c": None}}
+    root = ".."
+
+    ensure_folder_structure.run(config, root)
+    assert_leaf_folders(["a/b", "a/c", "sub"], base="..")
+
+
+def test_ensure_folder_structure_existing_files(tmpdir):
+    tmpdir.chdir()
+    tmpdir.mkdir("a")
+
+    with open("a/text", "w") as f:
+        f.write("Hello")
+
+    config = {"a": {"b": None, "c": None}}
+    ensure_folder_structure.run(config, ".")
+
+    with open("a/text") as f:
+        assert f.readline() == "Hello"
+
+
+def test_ensure_folder_structure_file_collision(tmpdir):
+    config = {"a": {"text": None, "c": None}}
+
+    with open("a/text", "w") as f:
+        f.write("Hello")
+
+    with pytest.raises(FileExistsError):
+        ensure_folder_structure.run(config, ".")
+
+    with open("a/text") as f:
+        assert f.readline() == "Hello"
+
+
+def test_ensure_folder_structure_abspath(tmpdir):
+    tmpdir.chdir()
+    config = {"a": {"/b": None, "c": None}}
+    with pytest.raises(ValueError) as exp:
+        ensure_folder_structure.run(config, ".")
+
+    assert "Configured structure cannot contain absolute elements" in str(exp.value)
+
+
+def test_ensure_folder_structure_back(tmpdir):
+    tmpdir.chdir()
+    config = {"a": {"..": None, "c": None}}
+    with pytest.raises(ValueError) as exp:
+        ensure_folder_structure.run(config, ".")
+
+    assert "Path elements should not contain '..'" in str(exp.value)
+
+
+def test_ensure_folder_structure_script(tmpdir):
+    tmpdir.chdir()
+
+    with open("config.yml", "w") as f:
+        f.write("""
+            a:
+              b:
+              c:
+            d:
+        """)
+
+    subprocess.check_call(["ensure_folder_structure.py", "config.yml"])
+
+    assert_leaf_folders(["a/b", "a/c", "d"], ".")


### PR DESCRIPTION
Example of a script that can be used to setup folders, both in the forward model and for workflows.

```yml
# example_config.yml
a:
  b:
  c:
    d:
e:
f:
```

**Forward model usage:**
In the forward model the job can be used as a replacement for multiple calls to `MAKE_DIRECTORY`. By using it as:

```
FORWARD_MODEL ENSURE_FOLDER_STRUCTURE(<CONFIG>=<CONFIG_PATH>/example_config.yml)
```

Will create the folders `a`, `e` and `f` in the runpath, and in addition create `b` and `c` inside `a`, and last `d` inside `c`.

**Workflow usage:**
The job can also be used as a workflow to create necessary folders that are expected to exist later on in the run.

The user will then have to create a workflow, i.e. `INIT_EXPERIMENT` which they can hook in their setup.
```
ENSURE_FOLDER_STRUCTURE <CONFIG_PATH>/example_config.yml -r=<CONFIG_PATH>/..
```

The folder structure described will in this setup be created one level down from the configuration file location. Notice the `-r` (short for `--root`) that allows you to change the root for where the folders are to be created. It is defaulted to cwd, which is why it will create it directly in the runpath in the forward model case.

Also, notice that it will not touch any existing files, only create the missing directories (if there are any missing). Hence, the name `ensure...`.
