### PR TITLE
Change default option of linkage to average

### DIFF
--- a/semeio/workflows/misfit_preprocessor/config.py
+++ b/semeio/workflows/misfit_preprocessor/config.py
@@ -23,10 +23,11 @@ _MAXCLUST_MONOCRIT = "maxclust_monocrit"
 _DEPTH = "depth"
 _LINKAGE = "linkage"
 _SINGLE = "single"
+_AVERAGE = "average"
 _METHODS = (
     _SINGLE,
     "complete",
-    "average",
+    _AVERAGE,
     "weighted",
     "centroid",
     "ward",
@@ -149,7 +150,7 @@ _LINKAGE_SCHEMA = {
                 "Method used to calculate the distance between the clusters."
             ),
             cs.MetaKeys.ElementValidators: (_one_of(*_METHODS),),
-            cs.MetaKeys.Default: _SINGLE,
+            cs.MetaKeys.Default: _AVERAGE,
         },
         _METRIC: {
             cs.MetaKeys.Type: cs.types.String,

--- a/tests/jobs/misfit_preprocessor/test_integration.py
+++ b/tests/jobs/misfit_preprocessor/test_integration.py
@@ -49,7 +49,7 @@ def test_misfit_preprocessor_main_entry_point_gen_data(monkeypatch, test_data_ro
     # call_args is a call object, which itself is a tuple of args and kwargs.
     # In this case, we want args, and the first element of the arguments, which
     # again is a tuple containing the configuration which is a list of configs.
-    assert len(list(run_mock.call_args)[0][0]) == 47, "wrong number of clusters"
+    assert len(list(run_mock.call_args)[0][0]) == 58, "wrong number of clusters"
 
 
 @pytest.mark.usefixtures("setup_tmpdir")

--- a/tests/jobs/misfit_preprocessor/unit/test_config.py
+++ b/tests/jobs/misfit_preprocessor/unit/test_config.py
@@ -255,7 +255,7 @@ def test_default_linkage_method():
     )
 
     assert config.valid, config.errors
-    assert "single" == config.snapshot.clustering.spearman_correlation.linkage.method
+    assert "average" == config.snapshot.clustering.spearman_correlation.linkage.method
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Testing has shown average to be a better method than single for real cases.

Closes #183 and #184 