### PR TITLE
Allow OTS to run without giving velocity model

### DIFF
--- a/semeio/jobs/overburden_timeshift/ots_config.py
+++ b/semeio/jobs/overburden_timeshift/ots_config.py
@@ -101,6 +101,8 @@ def build_schema():
             "velocity_model": {
                 MK.Type: types.String,
                 MK.Description: "Path to segy file containing the velocity field.",
+                MK.Default: None,
+                MK.AllowNone: True,
             },
             "mapaxes": {
                 MK.Type: types.Bool,

--- a/tests/jobs/overburden_timeshift/test_ots.py
+++ b/tests/jobs/overburden_timeshift/test_ots.py
@@ -55,7 +55,7 @@ def setUp():
 
 
 @pytest.mark.usefixtures("setup_tmpdir")
-def test_create(setUp):
+def test_invalid_input(setUp):
     spec, actnum, parms = setUp
     grid = EclGridGenerator.createRectangular(dims=(10, 10, 10), dV=(1, 1, 1))
 
@@ -126,25 +126,34 @@ def test_create(setUp):
             parms.velocity_model,
         )
 
+
+@pytest.mark.parametrize(
+    "config_item, value", [("velocity_model", "TEST.segy"), ("velocity_model", None)]
+)
+@pytest.mark.usefixtures("setup_tmpdir")
+def test_valid_input(setUp, config_item, value):
+    spec, actnum, params = setUp
     grid = EclGridGenerator.createRectangular(dims=(10, 10, 10), dV=(1, 1, 1))
 
     grid.save_EGRID("TEST.EGRID")
     create_init(grid, "TEST")
     create_restart(grid, "TEST")
 
-    parms.velocity_model = "TEST.segy"
-    create_segy_file(parms.velocity_model, spec)
+    # Testing individual items in config, so setting that value here:
+    setattr(params, config_item, value)
+    if params.velocity_model:
+        create_segy_file(params.velocity_model, spec)
 
     OverburdenTimeshift(
-        parms.eclbase,
-        parms.mapaxes,
-        parms.seabed,
-        parms.youngs,
-        parms.poisson,
-        parms.rfactor,
-        parms.convention,
-        parms.above,
-        parms.velocity_model,
+        params.eclbase,
+        params.mapaxes,
+        params.seabed,
+        params.youngs,
+        params.poisson,
+        params.rfactor,
+        params.convention,
+        params.above,
+        params.velocity_model,
     )
 
 

--- a/tests/jobs/overburden_timeshift/test_ots_config.py
+++ b/tests/jobs/overburden_timeshift/test_ots_config.py
@@ -7,7 +7,8 @@ from unittest import mock
 from datetime import datetime
 
 
-def test_valid_config(tmpdir, monkeypatch):
+@pytest.mark.parametrize("velocity_model", ["norne_vol.segy", None])
+def test_valid_config(tmpdir, monkeypatch, velocity_model):
     dates = ["1997-11-06", "1997-12-17", "1998-02-01", "1998-02-01"]
     context_mock = mock.Mock(
         return_value=[datetime.strptime(x, "%Y-%m-%d").date() for x in dates]
@@ -25,12 +26,13 @@ def test_valid_config(tmpdir, monkeypatch):
         "output_dir": "ts",
         "horizon": "horizon.irap",
         "ascii": "ts.txt",
-        "velocity_model": "norne_vol.segy",
         "vintages": {
             "ts_simple": [["1997-11-06", "1998-02-01"], ["1997-12-17", "1998-02-01"]],
             "dpv": [["1997-11-06", "1997-12-17"]],
         },
     }
+    if velocity_model:
+        conf.update({"velocity_model": velocity_model})
     with tmpdir.as_cwd():
         with open("ots_config.yml", "w") as f:
             yaml.dump(conf, f, default_flow_style=False)


### PR DESCRIPTION
This option was always possible in the code, it was just the configuration that did not reflect that.

Closes #215