### PR TITLE
Optional export

### DIFF
--- a/semeio/jobs/overburden_timeshift/ots.py
+++ b/semeio/jobs/overburden_timeshift/ots.py
@@ -91,7 +91,7 @@ def ots_run(parameter_file):
     if parms.horizon is not None:
         surface_horizon.write(parms.horizon)
 
-    if parms.ascii is not None:
+    if parms.vintages_export_file is not None:
         num_pairs = (
             len(vintage_pairs.ts)
             + len(vintage_pairs.ts_simple)
@@ -99,7 +99,7 @@ def ots_run(parameter_file):
             + len(vintage_pairs.ts_rporv)
         )
         line = "{}, {}, {}" + ", {}" * num_pairs + "\n"
-        with open(parms.ascii, "w") as f:
+        with open(parms.vintages_export_file, "w") as f:
             for point in range(len(surface_horizon)):
                 xy = surface_horizon.getXY(point)
                 ts = []

--- a/semeio/jobs/overburden_timeshift/ots_config.py
+++ b/semeio/jobs/overburden_timeshift/ots_config.py
@@ -87,6 +87,7 @@ def build_schema():
                 MK.Description: "Path to result irap file, the surface mapped to "
                 "the velocity grid, with the depth of horizon.",
                 MK.Default: None,
+                MK.AllowNone: True,
             },
             "eclbase": {
                 MK.Type: types.String,

--- a/semeio/jobs/overburden_timeshift/ots_config.py
+++ b/semeio/jobs/overburden_timeshift/ots_config.py
@@ -93,7 +93,7 @@ def build_schema():
                 MK.Type: types.String,
                 MK.Description: "Path to the Eclipse case.",
             },
-            "ascii": {
+            "vintages_export_file": {
                 MK.Type: types.String,
                 MK.Description: "Path to resulting text file, which contains all "
                 "computed vintage pair dates: lines of x, y, z, ts1, ts2, ts3....",

--- a/semeio/jobs/overburden_timeshift/ots_config.py
+++ b/semeio/jobs/overburden_timeshift/ots_config.py
@@ -98,6 +98,7 @@ def build_schema():
                 MK.Description: "Path to resulting text file, which contains all "
                 "computed vintage pair dates: lines of x, y, z, ts1, ts2, ts3....",
                 MK.Default: None,
+                MK.AllowNone: True,
             },
             "velocity_model": {
                 MK.Type: types.String,

--- a/tests/jobs/overburden_timeshift/test_ots.py
+++ b/tests/jobs/overburden_timeshift/test_ots.py
@@ -22,7 +22,7 @@ parms = namedtuple(
         "convention",
         "output_dir",
         "horizon",
-        "ascii",
+        "vintages_export_file",
         "velocity_model",
         "eclbase",
     ],
@@ -42,7 +42,7 @@ def set_up():
 
     parms.output_dir = None
     parms.horizon = None
-    parms.ascii = None
+    parms.vintages_export_file = None
     parms.velocity_model = None
     parms.seabed = 10
     parms.above = 10

--- a/tests/jobs/overburden_timeshift/test_ots_config.py
+++ b/tests/jobs/overburden_timeshift/test_ots_config.py
@@ -7,10 +7,12 @@ from unittest import mock
 from datetime import datetime
 
 
-@pytest.mark.parametrize("ascii_file", ["ts.txt", None])
+@pytest.mark.parametrize("vintages_export_file", ["ts.txt", None])
 @pytest.mark.parametrize("horizon", ["horizon.irap", None])
 @pytest.mark.parametrize("velocity_model", ["norne_vol.segy", None])
-def test_valid_config(tmpdir, monkeypatch, velocity_model, horizon, ascii_file):
+def test_valid_config(
+    tmpdir, monkeypatch, velocity_model, horizon, vintages_export_file
+):
     dates = ["1997-11-06", "1997-12-17", "1998-02-01", "1998-02-01"]
     context_mock = mock.Mock(
         return_value=[datetime.strptime(x, "%Y-%m-%d").date() for x in dates]
@@ -35,8 +37,8 @@ def test_valid_config(tmpdir, monkeypatch, velocity_model, horizon, ascii_file):
         conf.update({"velocity_model": velocity_model})
     if horizon:
         conf.update({"horizon": horizon})
-    if ascii_file:
-        conf.update({"ascii": ascii_file})
+    if vintages_export_file:
+        conf.update({"vintages_export_file": vintages_export_file})
 
     with tmpdir.as_cwd():
         with open("ots_config.yml", "w") as f:
@@ -61,7 +63,7 @@ def test_invalid_config(tmpdir, monkeypatch):
         "convention": 1,
         "output_dir": "ts",
         "horizon": "horizon.irap",
-        "ascii": "ts.txt",
+        "vintages_export_file": "ts.txt",
         "velocity_model": "norne_vol.segy",
         "vintages": {
             "ts_simple": [["1997-11-06", "1998-02-01"], ["1997-12-17", "1998-02-01"]],

--- a/tests/jobs/overburden_timeshift/test_ots_config.py
+++ b/tests/jobs/overburden_timeshift/test_ots_config.py
@@ -7,8 +7,9 @@ from unittest import mock
 from datetime import datetime
 
 
+@pytest.mark.parametrize("horizon", ["horizon.irap", None])
 @pytest.mark.parametrize("velocity_model", ["norne_vol.segy", None])
-def test_valid_config(tmpdir, monkeypatch, velocity_model):
+def test_valid_config(tmpdir, monkeypatch, velocity_model, horizon):
     dates = ["1997-11-06", "1997-12-17", "1998-02-01", "1998-02-01"]
     context_mock = mock.Mock(
         return_value=[datetime.strptime(x, "%Y-%m-%d").date() for x in dates]
@@ -24,7 +25,6 @@ def test_valid_config(tmpdir, monkeypatch, velocity_model):
         "mapaxes": False,
         "convention": 1,
         "output_dir": "ts",
-        "horizon": "horizon.irap",
         "ascii": "ts.txt",
         "vintages": {
             "ts_simple": [["1997-11-06", "1998-02-01"], ["1997-12-17", "1998-02-01"]],
@@ -33,6 +33,9 @@ def test_valid_config(tmpdir, monkeypatch, velocity_model):
     }
     if velocity_model:
         conf.update({"velocity_model": velocity_model})
+    if horizon:
+        conf.update({"horizon": horizon})
+
     with tmpdir.as_cwd():
         with open("ots_config.yml", "w") as f:
             yaml.dump(conf, f, default_flow_style=False)

--- a/tests/jobs/overburden_timeshift/test_ots_config.py
+++ b/tests/jobs/overburden_timeshift/test_ots_config.py
@@ -7,9 +7,10 @@ from unittest import mock
 from datetime import datetime
 
 
+@pytest.mark.parametrize("ascii_file", ["ts.txt", None])
 @pytest.mark.parametrize("horizon", ["horizon.irap", None])
 @pytest.mark.parametrize("velocity_model", ["norne_vol.segy", None])
-def test_valid_config(tmpdir, monkeypatch, velocity_model, horizon):
+def test_valid_config(tmpdir, monkeypatch, velocity_model, horizon, ascii_file):
     dates = ["1997-11-06", "1997-12-17", "1998-02-01", "1998-02-01"]
     context_mock = mock.Mock(
         return_value=[datetime.strptime(x, "%Y-%m-%d").date() for x in dates]
@@ -25,7 +26,6 @@ def test_valid_config(tmpdir, monkeypatch, velocity_model, horizon):
         "mapaxes": False,
         "convention": 1,
         "output_dir": "ts",
-        "ascii": "ts.txt",
         "vintages": {
             "ts_simple": [["1997-11-06", "1998-02-01"], ["1997-12-17", "1998-02-01"]],
             "dpv": [["1997-11-06", "1997-12-17"]],
@@ -35,6 +35,8 @@ def test_valid_config(tmpdir, monkeypatch, velocity_model, horizon):
         conf.update({"velocity_model": velocity_model})
     if horizon:
         conf.update({"horizon": horizon})
+    if ascii_file:
+        conf.update({"ascii": ascii_file})
 
     with tmpdir.as_cwd():
         with open("ots_config.yml", "w") as f:

--- a/tests/jobs/overburden_timeshift/test_ots_integration.py
+++ b/tests/jobs/overburden_timeshift/test_ots_integration.py
@@ -40,7 +40,7 @@ def test_ots_config_run_parameters(
         "convention": 1,
         "output_dir": "ts",
         "horizon": "horizon.irap",
-        "ascii": "ts.txt",
+        "vintages_export_file": "ts.txt",
         "velocity_model": "norne_vol.segy",
         "vintages": {
             "ts_simple": [["1997-11-06", "1998-02-01"], ["1997-12-17", "1998-01-01"]],


### PR DESCRIPTION
`ascii` and `horizon` export is optional in the code, but not in the configuration, this fixes that. 

Closes #218 
Closes #219 