### PR TITLE
Add integration test for csv_export2 through mocked ert config

### DIFF
--- a/tests/jobs/csv_export2/conftest.py
+++ b/tests/jobs/csv_export2/conftest.py
@@ -74,6 +74,9 @@ def mock_norne_data(reals, iters, parameters=True):
             if parameters:
                 with open(os.path.join(runpath, "parameters.txt"), "w") as p_fileh:
                     p_fileh.write("FOO 1{}{}".format(real, iteration))
+            # Ensure fmu-ensemble does not complain on missing STATUS
+            with open(os.path.join(runpath, "STATUS"), "w") as file_h:
+                file_h.write("a:b\na: 09:00:00 .... 09:00:01")
 
     with open("runpathfile", "w") as file_h:
         for iteration in iters:

--- a/tests/jobs/csv_export2/test_integration.py
+++ b/tests/jobs/csv_export2/test_integration.py
@@ -1,3 +1,7 @@
+import os
+import sys
+import subprocess
+
 import pytest
 import rstcheck
 import pandas as pd
@@ -186,3 +190,84 @@ def verifyExportedFile(exported_file_name, result_header, result_iter_rel):
         set(dframe[["ENSEMBLE", "REAL"]].itertuples(index=False, name=None))
         == result_iter_rel
     )
+
+
+@pytest.mark.integration
+def test_ert_integration(norne_mocked_ensembleset):
+    """Mock an ERT config and test the workflow"""
+    with open("FOO.DATA", "w") as file_h:
+        file_h.write("--Empty")
+
+    with open("wf_csvexport", "w") as file_h:
+        file_h.write(
+            (
+                # This workflow is representing the example in csv_export2.py:
+                (
+                    "MAKE_DIRECTORY csv_output\n"
+                    "EXPORT_RUNPATH * | *\n"  # (not really relevant in mocked case)
+                    "CSV_EXPORT2 runpathfile csv_output/data.csv monthly FOPT\n"
+                    # Example in documentation uses <RUNPATH_FILE> which is
+                    # linked to the RUNPATH keyword that we don't use in this
+                    # test (mocking data gets more complex if that is to be used)
+                )
+            )
+        )
+
+    ert_config = [
+        "ECLBASE FOO.DATA",
+        "QUEUE_SYSTEM LOCAL",
+        "NUM_REALIZATIONS 2",
+        "LOAD_WORKFLOW wf_csvexport",
+        "HOOK_WORKFLOW wf_csvexport PRE_SIMULATION",
+    ]
+
+    ert_config_fname = "test.ert"
+    with open(ert_config_fname, "w") as file_h:
+        file_h.write("\n".join(ert_config))
+
+    subprocess.run(["ert", "test_run", ert_config_fname], check=True)
+
+    assert pd.read_csv("csv_output/data.csv").shape == (16, 5)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="Py 3.7 for capture_output")
+@pytest.mark.integration
+def test_ert_integration_errors(norne_mocked_ensembleset):
+    """Test CSV_EXPORT2 when runpathfile points to non-existing realizations
+
+    This test proves that CSV_EXPORT2 happily skips non-existing
+    realizations, but emits a warning that there is no STATUS file.
+    """
+    with open("FOO.DATA", "w") as file_h:
+        file_h.write("--Empty")
+
+    # Append a not-existing realizations to the runpathfile:
+    with open("runpathfile", "a") as file_h:
+        file_h.write("002 realization-2/iter-0 NORNE_1 000")
+
+    with open("wf_csvexport", "w") as file_h:
+        file_h.write("CSV_EXPORT2 runpathfile data.csv monthly FOPT\n")
+
+    ert_config = [
+        "ECLBASE FOO.DATA",
+        "QUEUE_SYSTEM LOCAL",
+        "NUM_REALIZATIONS 2",
+        "LOAD_WORKFLOW wf_csvexport",
+        "HOOK_WORKFLOW wf_csvexport PRE_SIMULATION",
+    ]
+
+    ert_config_fname = "test.ert"
+    with open(ert_config_fname, "w") as file_h:
+        file_h.write("\n".join(ert_config))
+
+    ertoutput = subprocess.run(
+        ["ert", "test_run", ert_config_fname], check=True, capture_output=True
+    )
+
+    assert "fmu.ensemble.realization - WARNING - No STATUS file" in str(
+        ertoutput.stdout
+    )
+    assert "realization-2/iter-0" in str(ertoutput.stdout)
+
+    assert os.path.exists("data.csv")
+    assert pd.read_csv("data.csv").shape == (16, 5)

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,9 @@ addopts =
     -ra
     --durations=5
 
+markers =
+    integration: marks a test as an integration test
+
 [flake8]
 max-line-length = 88
 exclude = tests/legacy_test_data


### PR DESCRIPTION
Exposes bug in libres 7.1.0, MAKE_DIRECTORY is not recognized as a workflow job

The test pass if MAKE_DIRECTORY is taken out.

MAKE_DIRECTORY should be present in the test, because the inline documentation for csv_export uses MAKE_DIRECTORY.