### PR TITLE
New config

### DIFF
--- a/semeio/workflows/misfit_preprocessor/misfit_preprocessor.py
+++ b/semeio/workflows/misfit_preprocessor/misfit_preprocessor.py
@@ -36,30 +36,11 @@ class MisfitPreprocessorJob(SemeioScript):
         # The execution of COS should be moved into
         # misfit_preprocessor.run when COS no longer depend on self.ert
         # to run.
-        scaling_params = _fetch_scaling_parameters(config_record, observations)
-        for scaling_config in scaling_configs:
-            scaling_config["CALCULATE_KEYS"].update(scaling_params)
 
         try:
             CorrelatedObservationsScalingJob(self.ert()).run(scaling_configs)
         except EmptyDatasetException:
             pass
-
-
-def _fetch_scaling_parameters(config_record, observations):
-    config = misfit_preprocessor.assemble_config(
-        config_record,
-        observations,
-    )
-    if not config.valid:
-        # The config is loaded by misfit_preprocessor.run first. The
-        # second time should never fail!
-        raise ValueError("Misfit preprocessor config not valid on second load")
-
-    scale_conf = config.snapshot.scaling
-    return {
-        "threshold": scale_conf.threshold,
-    }
 
 
 def _fetch_config_record(args):

--- a/tests/jobs/misfit_preprocessor/test_integration.py
+++ b/tests/jobs/misfit_preprocessor/test_integration.py
@@ -39,9 +39,8 @@ def test_misfit_preprocessor_main_entry_point_gen_data(
 
     config = {
         "observations": [observation],
-        "clustering": {
-            "method": "spearman_correlation",
-            "spearman_correlation": {"fcluster": {"t": 1.0}},
+        "workflow": {
+            "spearman_correlation": {"clustering": {"hierarchical": {"t": 1.0}}},
         },
     }
     config_file = "my_config_file.yaml"
@@ -79,9 +78,11 @@ def test_misfit_preprocessor_passing_scaling_parameters(monkeypatch, test_data_r
     ert = EnKFMain(res_config)
 
     config = {
-        "clustering": {"method": "spearman_correlation"},
-        "scaling": {"threshold": 0.5, "std_cutoff": 2, "alpha": 3},
+        "workflow": {
+            "spearman_correlation": {"pca": {"threshold": 0.5}},
+        },
     }
+
     config_file = "my_config_file.yaml"
     with open(config_file, "w") as f:
         yaml.dump(config, f)
@@ -126,9 +127,12 @@ def test_misfit_preprocessor_with_scaling(test_data_root):
     ert = EnKFMain(res_config)
 
     config = {
-        "clustering": {
-            "method": "spearman_correlation",
-            "spearman_correlation": {"fcluster": {"t": 1.0}},
+        "workflow": {
+            "spearman_correlation": {
+                "clustering": {
+                    "hierarchical": {"t": 1.0},
+                }
+            },
         }
     }
     config_file = "my_config_file.yaml"
@@ -168,9 +172,9 @@ def test_misfit_preprocessor_skip_clusters_yielding_empty_data_matrixes(
     ert = EnKFMain(res_config)
 
     config = {
-        "clustering": {
+        "workflow": {
             "method": "spearman_correlation",
-            "spearman_correlation": {"fcluster": {"t": 1.0}},
+            "spearman_correlation": {"clustering": {"hierarchical": {"t": 1.0}}},
         }
     }
     config_file = "my_config_file.yaml"
@@ -197,9 +201,11 @@ def test_misfit_preprocessor_invalid_config(test_data_root):
 
     config = {
         "unknown_key": [],
-        "clustering": {
+        "workflow": {
             "method": "spearman_correlation",
-            "spearman_correlation": {"fcluster": {"threshold": 1.0}},
+            "spearman_correlation": {
+                "clustering": {"hierarchical": {"threshold": 1.0}}
+            },
         },
     }
     config_file = "my_config_file.yaml"
@@ -213,7 +219,8 @@ def test_misfit_preprocessor_invalid_config(test_data_root):
     expected_err_msg = (
         "Invalid configuration of misfit preprocessor\n"
         "  - Unknown key: unknown_key (root level)\n"
-        "  - Unknown key: threshold (clustering.spearman_correlation.fcluster)\n"
+        "  - Unknown key: "
+        "threshold (workflow.spearman_correlation.clustering.hierarchical)\n"
     )
     assert expected_err_msg == str(ve.value)
 

--- a/tests/jobs/misfit_preprocessor/test_misfit_preprocessor.py
+++ b/tests/jobs/misfit_preprocessor/test_misfit_preprocessor.py
@@ -170,7 +170,7 @@ def test_misfit_preprocessor_n_polynomials(num_polynomials, method):
     # to have an impact. Setting it this way only has an impact for "auto_scale"
     obs_keys = measured_data.data.columns.get_level_values(0)
     config = assemble_config(
-        {"clustering": {"method": method}, "scaling": {"threshold": 0.99}},
+        {"workflow": {method: {"pca": {"threshold": 0.99}}}},
         obs_keys,
     )
     reporter_mock = Mock()
@@ -204,8 +204,12 @@ def test_misfit_preprocessor_state_size(state_size, method, linkage):
     obs_keys = measured_data.data.columns.get_level_values(0)
     config = assemble_config(
         {
-            "clustering": {"method": method, method: {"linkage": {"method": linkage}}},
-            "scaling": {"threshold": 0.99},
+            "workflow": {
+                method: {
+                    "clustering": {"hierarchical": {"method": linkage}},
+                    "pca": {"threshold": 0.99},
+                }
+            },
         },
         obs_keys,
     ).snapshot
@@ -232,11 +236,15 @@ def test_misfit_preprocessor_state_uneven_size(state_size):
     obs_keys = measured_data.data.columns.get_level_values(0)
     config = assemble_config(
         {
-            "clustering": {
-                "method": "spearman_correlation",
+            "workflow": {
                 "spearman_correlation": {
-                    "fcluster": {"t": num_polynomials + 1, "criterion": "maxclust"}
-                },
+                    "clustering": {
+                        "hierarchical": {
+                            "t": num_polynomials + 1,
+                            "criterion": "maxclust",
+                        }
+                    },
+                }
             }
         },
         obs_keys,
@@ -252,9 +260,10 @@ def test_misfit_preprocessor_configuration_errors():
         assemble_config(
             {
                 "unknown_key": ["not in set"],
-                "clustering": {
-                    "method": "spearman_correlation",
-                    "spearman_correlation": {"fcluster": {"threshold": 1.0}},
+                "workflow": {
+                    "spearman_correlation": {
+                        "clustering": {"hierarchical": {"threshold": 1.0}}
+                    },
                 },
             },
             ["a", "list", "of", "observations"],
@@ -263,7 +272,8 @@ def test_misfit_preprocessor_configuration_errors():
     expected_err_msg = (
         "Invalid configuration of misfit preprocessor\n"
         "  - Unknown key: unknown_key (root level)\n"
-        "  - Unknown key: threshold (clustering.spearman_correlation.fcluster)\n"
+        "  - Unknown key: threshold "
+        "(workflow.spearman_correlation.clustering.hierarchical)\n"
     )
     assert expected_err_msg == str(ve.value)
 
@@ -288,8 +298,9 @@ def test_misfit_preprocessor_n_polynomials_w_correlation(num_polynomials):
 
     config = assemble_config(
         {
-            "clustering": {"method": "spearman_correlation"},
-            "scaling": {"threshold": 0.99},
+            "workflow": {
+                "spearman_correlation": {"pca": {"threshold": 0.99}},
+            }
         },
         list(measured_data.data.columns.get_level_values(0)),
     ).snapshot


### PR DESCRIPTION
Solves #191 
Peer-programming with @oyvindeide :1st_place_medal: 

The new configuration proposed in #ert-research.

```
input_data:
  alpha: 2  # remove from config?
  std_cutoff: 0.001  # remove from config?
  observations:
    - W*
    - FOPT
workflow:
    auto_scale:  # optional, mutually exclusive with spearman_correlation
      clustering:  # optional
        hierarchical:  # optional, mutually exclusive with kmeans
            method: complete  # optional
            metric: jensenshannon  # optional
        kmeans:  # optional, mutually exclusive with hierarchical
      pca:  # optional
        threshold: 0.99    
    spearman_correlation:  # optional, mutually exclusive with auto_scale
        clustering:  # optional
           hierarchical:  # optional, mutually exclusive with kmeans
             method: centroid  # optional
             metric: dice  # optional
             criterion: maxclust  # optional
             t: 10  # optional
           kmeans:  # mutually exclusive with hierarchical
             some_option: 2
        pca:  # optional
           threshold: 0.98
```