### PR TITLE
Let csv_export2 work without runpathfile

### DIFF
--- a/semeio/workflows/csv_export2/csv_export2.py
+++ b/semeio/workflows/csv_export2/csv_export2.py
@@ -1,5 +1,6 @@
 import argparse
 import sys
+from pathlib import Path
 
 import pandas as pd
 from ert_shared.plugins.plugin_manager import hook_implementation
@@ -76,9 +77,14 @@ def csv_exporter(runpathfile, time_index, outputfile, column_keys=None):
 
     The EnsembleSet is described by a runpathfile which must exists
     and point to realizations"""
-    ensemble_set = ensemble.EnsembleSet(
-        name="ERT EnsembleSet for CSV_EXPORT2", runpathfile=runpathfile
-    )
+    if Path(runpathfile).exists():
+        ensemble_set = ensemble.EnsembleSet(
+            name="ERT EnsembleSet for CSV_EXPORT2", runpathfile=runpathfile
+        )
+    else:
+        ensemble_set = ensemble.EnsembleSet(
+            name="ad-hoc filesystem EnsembleSet", frompath=runpathfile
+        )
     summary = ensemble_set.load_smry(time_index=time_index, column_keys=column_keys)
     try:  # try/except is needed for fmu-ensemble<=1.3.0
         parameters = ensemble_set.parameters
@@ -118,7 +124,9 @@ def csv_export_parser():
         type=str,
         help=(
             "Path to ERT RUNPATH-file, "
-            "usually the ERT magic variable <RUNPATH> can be used"
+            "usually the ERT magic variable <RUNPATH> can be used. "
+            "Alternatively a wildcard path to realizations, enclosed "
+            "in quotes."
         ),
     )
     parser.add_argument(

--- a/tests/jobs/csv_export2/conftest.py
+++ b/tests/jobs/csv_export2/conftest.py
@@ -42,7 +42,7 @@ def ert_statoil_test_data(tmpdir):
     os.chdir(cwd)
 
 
-def mock_norne_data(reals, iters, parameters=True):
+def mock_norne_data(reals, iters, parameters=True, ecldir="."):
     """From a single UNSMRY file, produce arbitrary sized ensembles.
 
     Summary data will be equivalent over realizations, but the
@@ -54,6 +54,7 @@ def mock_norne_data(reals, iters, parameters=True):
         reals (list): integers with realization indices wanted
         iters (list): integers with iter indices wanted
         parameters (bool): Whether to write parameters.txt in each runpath
+        ecldir (str): Directory to put Eclipse files in.
     """
     for real in reals:
         for iteration in iters:
@@ -63,14 +64,20 @@ def mock_norne_data(reals, iters, parameters=True):
 
             os.makedirs(runpath, exist_ok=True)
 
+            os.makedirs(os.path.join(runpath, ecldir), exist_ok=True)
+
             os.symlink(
                 os.path.join(NORNE_DIR, "NORNE_ATW2013.UNSMRY"),
-                os.path.join(runpath, "NORNE_{}.UNSMRY".format(real)),
+                os.path.join(runpath, ecldir, "NORNE_{}.UNSMRY".format(real)),
             )
             os.symlink(
                 os.path.join(NORNE_DIR, "NORNE_ATW2013.SMSPEC"),
-                os.path.join(runpath, "NORNE_{}.SMSPEC".format(real)),
+                os.path.join(runpath, ecldir, "NORNE_{}.SMSPEC".format(real)),
             )
+            with open(
+                os.path.join(runpath, ecldir, "NORNE_{}.DATA".format(real)), "w"
+            ) as datafile_h:
+                datafile_h.write("-- Placeholder")
             if parameters:
                 with open(os.path.join(runpath, "parameters.txt"), "w") as p_fileh:
                     p_fileh.write("FOO 1{}{}".format(real, iteration))
@@ -92,6 +99,11 @@ def mock_norne_data(reals, iters, parameters=True):
 @pytest.fixture()
 def norne_mocked_ensembleset(setup_tmpdir):
     mock_norne_data(reals=[0, 1], iters=[0, 1], parameters=True)
+
+
+@pytest.fixture()
+def norne_mocked_ensembleset_ecldir(setup_tmpdir):
+    mock_norne_data(reals=[0, 1], iters=[0, 1], parameters=True, ecldir="eclipse/model")
 
 
 @pytest.fixture()

--- a/tests/jobs/csv_export2/test_integration.py
+++ b/tests/jobs/csv_export2/test_integration.py
@@ -172,6 +172,26 @@ def test_norne_ensemble_noparams(norne_mocked_ensembleset_noparams):
     )
 
 
+@pytest.mark.usefixtures("norne_mocked_ensembleset_ecldir")
+def test_globbed_path(norne_mocked_ensembleset_ecldir):
+    csv_export2.csv_exporter(
+        runpathfile="realization-*/iter-*",
+        time_index="yearly",
+        outputfile="unsmry--yearly.csv",
+        column_keys=["F?PT"],
+    )
+    verifyExportedFile(
+        "unsmry--yearly.csv",
+        ["ENSEMBLE", "REAL", "DATE"] + NORNE_VECS + ["FOO"],
+        {
+            ("iter-0", 0),
+            ("iter-0", 1),
+            ("iter-1", 0),
+            ("iter-1", 1),
+        },
+    )
+
+
 def verifyExportedFile(exported_file_name, result_header, result_iter_rel):
     """Verify an exported CSV file with respect to:
 


### PR DESCRIPTION
Makes csv_export2 a handy debugging tool, skipping the need
to generate a runpathfile. Relevant in failed scenarios etc.

More robustness can be coded if this PR will be accepted, i.e. if user forgets to quote `"realization-*/iter-*"` the current PR will error.