### PR TITLE
Use EXECUTABLE since PORTABLE_EXE is deprecated.

### DIFF
--- a/semeio/jobs/config_jobs/DESIGN2PARAMS
+++ b/semeio/jobs/config_jobs/DESIGN2PARAMS
@@ -3,7 +3,7 @@ STDOUT DESIGN2PARAMS.stdout
 
 TARGET_FILE DESIGN2PARAMS.OK
 
-PORTABLE_EXE design2params
+EXECUTABLE design2params
 ARGLIST      <IENS> <xls_filename> <designsheet> <defaultssheet>
 
 MIN_ARG    3

--- a/semeio/jobs/config_jobs/DESIGN_KW
+++ b/semeio/jobs/config_jobs/DESIGN_KW
@@ -3,7 +3,7 @@ STDOUT DESIGN_KW.stdout
 
 TARGET_FILE DESIGN_KW.OK
 
-PORTABLE_EXE design_kw
+EXECUTABLE design_kw
 ARGLIST      <template_file> <result_file>
 
 MIN_ARG    2


### PR DESCRIPTION
Resolves #331 