### PR TITLE
ahm_analysis script: Correct misfit calculation and update test 

### DIFF
--- a/semeio/workflows/ahm_analysis/ahmanalysis.py
+++ b/semeio/workflows/ahm_analysis/ahmanalysis.py
@@ -440,7 +440,7 @@ def calc_observationsgroup_misfit(obs_keys, df_update_log, misfit_df):
         mean = (
             misfit_df[df_misfit_calc["Misfit_key"].to_list()].sum(axis=1) / total_obs_nr
         )
-    return mean.loc[0]
+    return mean.mean()
 
 
 def load_grid_to_dataframe(grid_path):

--- a/tests/jobs/ahm_analysis/test_ahm_analysis.py
+++ b/tests/jobs/ahm_analysis/test_ahm_analysis.py
@@ -59,7 +59,7 @@ def test_count_active_observations():
     [
         (
             "RWI_3_OBS",
-            2.0,
+            (2.0 + 10.0 / 3.0) / 2.0,
             {
                 "obs_key": {0: "RWI_3_OBS", 1: "RWI_3_OBS", 2: "RWI_3_OBS"},
                 "status": {0: "Active", 1: "Inactive", 2: "Active"},
@@ -67,7 +67,7 @@ def test_count_active_observations():
         ),
         (
             "All_obs",
-            7.0 / 3.0,
+            (7.0 / 3.0 + 11.5 / 3.0) / 2.0,
             {
                 "obs_key": {
                     0: "RWI_3_OBS",
@@ -87,7 +87,7 @@ def test_count_active_observations():
         ),
         (
             "OP_3_WWCT",
-            1.4 / 3.0,
+            (1.4 / 3.0 + 1.8 / 3.0) / 2.0,
             {
                 "obs_key": {0: "OP_3_WWCT1", 1: "OP_3_WWCT2", 2: "OP_3_WWCT3"},
                 "status": {0: "Active", 1: "Inactive", 2: "Active"},
@@ -100,10 +100,10 @@ def test_calc_observationsgroup_misfit(input_obs, expected_misfit, update_log):
     reporting misfit data for each obs vector"""
     misfit_df = pd.DataFrame(
         {
-            "MISFIT:RWI_3_OBS": [6],
-            "MISFIT:OP_3_WWCT1": [1],
-            "MISFIT:OP_3_WWCT2": [0.15],
-            "MISFIT:OP_3_WWCT3": [0.25],
+            "MISFIT:RWI_3_OBS": [6, 10],
+            "MISFIT:OP_3_WWCT1": [1, 1.5],
+            "MISFIT:OP_3_WWCT2": [0.15, 0.2],
+            "MISFIT:OP_3_WWCT3": [0.25, 0.1],
         }
     )
     update_log_df = pd.DataFrame(update_log)


### PR DESCRIPTION
This is to correct the calc_observationsgroup_misfit function to actually return the average of the misfit over all the realizations in the ensemble and not only the  value of realization 0. This also then prevents the workflow to fail if realization 0 has failed ( so has no data).