### PR TITLE
Remove temporary test folder after execution

### DIFF
--- a/tests/jobs/csv_export2/conftest.py
+++ b/tests/jobs/csv_export2/conftest.py
@@ -40,6 +40,7 @@ def ert_statoil_test_data(tmpdir):
     yield
 
     os.chdir(cwd)
+    tmpdir.remove()
 
 
 def mock_norne_data(reals, iters, parameters=True):


### PR DESCRIPTION
Resolves https://github.com/equinor/semeio/issues/337

Removes temporary folder after test execution for disk intensive tests. 