### PR TITLE
Update test according to one extra observation being read

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     ],
     install_requires=[
         "ecl",
-        "ert >= 2.25.0b1",
+        "ert >= 2.27.0rc1",
         "configsuite>=0.6",
         "numpy",
         "pandas>0.24",

--- a/tests/jobs/misfit_preprocessor/test_integration.py
+++ b/tests/jobs/misfit_preprocessor/test_integration.py
@@ -16,7 +16,7 @@ from unittest.mock import Mock
 
 @pytest.mark.usefixtures("setup_tmpdir")
 @pytest.mark.parametrize(
-    "observation, expected_nr_clusters", [["*", 58], ["WPR_DIFF_1", 1]]
+    "observation, expected_nr_clusters", [["*", 60], ["WPR_DIFF_1", 1]]
 )
 def test_misfit_preprocessor_main_entry_point_gen_data(
     monkeypatch, test_data_root, observation, expected_nr_clusters


### PR DESCRIPTION
After an update in ert, one additional observation point is loaded, that has the effect of loading additional responses, and as a result the expected number of clusters has been wrong.