### PR TITLE
Remove mention of removed ERT keyword CUSTOM_KW

### DIFF
--- a/semeio/jobs/scripts/design2params.py
+++ b/semeio/jobs/scripts/design2params.py
@@ -12,7 +12,7 @@ Reads a design matrix in XLSX-format and
   key-value pairs to parameters.txt
 * Converts specified worksheet to txt-format and puts designmatrix.txt in RUNPATH
 * Creates designparameters.txt which only contains variables taken from the design
-  matrix, this can be given to CUSTOM_KW
+  matrix
 
 Requires a matrix with column header as strings in topmost row in xls-file.
 Row 2 in xls-file must then correspond with the data you want for realization-0

--- a/tests/legacy_test_data/snake_oil/snake_oil.ert
+++ b/tests/legacy_test_data/snake_oil/snake_oil.ert
@@ -26,7 +26,6 @@ FORWARD_MODEL SNAKE_OIL_DIFF
 
 RUN_TEMPLATE templates/seed_template.txt seed.txt
 GEN_KW SNAKE_OIL_PARAM templates/snake_oil_template.txt snake_oil_params.txt parameters/snake_oil_parameters.txt
-CUSTOM_KW SNAKE_OIL_NPV snake_oil_npv.txt
 GEN_DATA SNAKE_OIL_OPR_DIFF INPUT_FORMAT:ASCII RESULT_FILE:snake_oil_opr_diff_%d.txt REPORT_STEPS:199
 GEN_DATA SNAKE_OIL_WPR_DIFF INPUT_FORMAT:ASCII RESULT_FILE:snake_oil_wpr_diff_%d.txt REPORT_STEPS:199
 GEN_DATA SNAKE_OIL_GPR_DIFF INPUT_FORMAT:ASCII RESULT_FILE:snake_oil_gpr_diff_%d.txt REPORT_STEPS:199

--- a/tests/legacy_test_data/snake_oil/snake_oil_field.ert
+++ b/tests/legacy_test_data/snake_oil/snake_oil_field.ert
@@ -27,7 +27,6 @@ FORWARD_MODEL SNAKE_OIL_DIFF
 
 RUN_TEMPLATE templates/seed_template.txt seed.txt
 GEN_KW SNAKE_OIL_PARAM templates/snake_oil_template.txt snake_oil_params.txt parameters/snake_oil_parameters.txt
-CUSTOM_KW SNAKE_OIL_NPV snake_oil_npv.txt
 
 FIELD PERMX  PARAMETER snake_oil_permx.grdecl   INIT_FILES:fields/permx%d.grdecl
 FIELD PORO  PARAMETER snake_oil_poro.grdecl   INIT_FILES:fields/poro%d.grdecl


### PR DESCRIPTION
CUSTOM_KW has been gone for a long time.

Its presence causes warnings when running tests, and the documentation for `DESIGN2PARMAMS` was wrong. 