### PR TITLE
Modified localisation config file for ref_point keyword

### DIFF
--- a/semeio/workflows/localisation/local_config_script.py
+++ b/semeio/workflows/localisation/local_config_script.py
@@ -131,7 +131,7 @@ with ``aps_``. ::
           main_range: 1700
           perp_range: 850
           azimuth: 310
-       ref_point: [463400, 5932915]
+          ref_point: [463400, 5932915]
 
     - name: CORR2
        obs_group:
@@ -144,8 +144,9 @@ with ``aps_``. ::
           main_range: 800
           perp_range: 350
           azimuth: 120
+          ref_point: [463000, 5932850]
           surface_file: "../../rms/output/hum/TopVolantis.irap"
-       ref_point: [463000, 5932850]
+
 
    - name: CORR3
        obs_group:
@@ -156,7 +157,6 @@ with ``aps_``. ::
           method: from_file
           filename: "scaling_aps_volon_grf.grdecl"
           param_name: "SCALING"
-       ref_point: [463000, 5932850]
 
    - name: CORR4
        obs_group:
@@ -169,7 +169,7 @@ with ``aps_``. ::
           param_name: "REGION"
           active_segments: [ 1,2,4]
           scalingfactors: [1.0, 0.5, 0.3]
-       ref_point: [463000, 5932850]
+
 
 Keywords
 -----------
@@ -240,12 +240,6 @@ Keywords
       Sub keywords: **method** and **surface_file**. Depending on which
       method is chosen, additional keywords must be specified.
 
-:ref_point:
-      Optional, but required if  **field_scale**  or **surface_scale** keywords
-      are used. Sub keyword under a correlation group.
-      The keyword is followed by a list of x and y coordinates for the reference point.
-
-
 :add:
       Sub keyword under **obs_group** and **param_group**. Both **add**
       and **remove** keywords are followed by a list of observations or
@@ -301,8 +295,8 @@ Keywords
       distance from reference point to location of a field value, and *R* is the
       range function, an ellipse with half-axes equal to **main_range** and
       **perp_range**.
-      Requires specification of keywords **main_range**, **perp_range**
-      and **azimuth**.
+      Requires specification of keywords **main_range**, **perp_range**,
+      **azimuth** and **ref_point**.
 
 :gaussian_decay:
       Scaling function of the form *exp(-3(d/R)^2)*.
@@ -325,6 +319,15 @@ Keywords
       method **exponential_decay** and **gaussian_decay**.
       It defines the azimuth direction for main anisotropy direction
       for the decay function for scaling factor.
+
+:ref_point:
+      Sub keyword under  **field_scale**  or **surface_scale**. Is only used for
+      method **exponential_decay** and **gaussian_decay**.
+      It defines the (x,y) position the used by the scaling functions when calculating
+      distance to a grid cell with a field parameter value. A grid cell located at the
+      reference point will have distance 0 which means that the scaling function is
+      1.0 for correlations between observations and the field parameter in that
+      location.
 
 :surface_file:
       Sub keyword under **surface_scale**. Is required and specify filename for

--- a/semeio/workflows/localisation/local_script_lib.py
+++ b/semeio/workflows/localisation/local_script_lib.py
@@ -590,7 +590,7 @@ def add_ministeps(
                     assert data_size == data_size2
                     param_for_field = None
                     if corr_spec.field_scale.method in _decay_methods_fields:
-                        ref_pos = corr_spec.ref_point
+                        ref_pos = corr_spec.field_scale.ref_point
                         main_range = corr_spec.field_scale.main_range
                         perp_range = corr_spec.field_scale.perp_range
                         azimuth = corr_spec.field_scale.azimuth
@@ -692,7 +692,7 @@ def add_ministeps(
                     data_size = surface.getNX() * surface.getNY()
                     row_scaling = model_param_group.row_scaling(node_name)
                     if corr_spec.surface_scale.method in _decay_methods_surf:
-                        ref_pos = corr_spec.ref_point
+                        ref_pos = corr_spec.surface_scale.ref_point
                         main_range = corr_spec.surface_scale.main_range
                         perp_range = corr_spec.surface_scale.perp_range
                         azimuth = corr_spec.surface_scale.azimuth

--- a/semeio/workflows/localisation/localisation_config.py
+++ b/semeio/workflows/localisation/localisation_config.py
@@ -143,6 +143,7 @@ class GaussianConfig(BaseModel):
     main_range: confloat(gt=0)
     perp_range: confloat(gt=0)
     azimuth: confloat(ge=0.0, le=360)
+    ref_point: conlist(float, min_items=2, max_items=2)
     surface_file: Optional[str]
 
 
@@ -217,7 +218,6 @@ class CorrelationConfig(BaseModel):
     name: str
     obs_group: ObsConfig
     param_group: ParamConfig
-    ref_point: Optional[conlist(float, min_items=2, max_items=2)]
     field_scale: Optional[
         Union[
             GaussianConfig,
@@ -260,36 +260,6 @@ class CorrelationConfig(BaseModel):
             raise ValueError(
                 f"Unknown method: {method}, valid methods are: {valid_list}"
             )
-
-    @root_validator()
-    def valid_ref_point_and_scale(cls, values: Dict) -> Dict:
-        field_scale = values.get("field_scale", None)
-        surface_scale = values.get("surface_scale", None)
-        ref_point = values.get("ref_point")
-        if field_scale is not None:
-            # ref_point is required for method:
-            # - gaussian_decay
-            # - exponential_decay
-            if field_scale.method in ["gaussian_decay", "exponential_decay"]:
-                if ref_point is None:
-                    raise ValueError(
-                        "When using FIELD with scaling of correlation with "
-                        f"method {field_scale.method}, "
-                        "the reference point must be specified."
-                    )
-        if surface_scale is not None:
-            # ref_point is required for method:
-            # - gaussian_decay
-            # - exponential_decay
-            if surface_scale.method in ["gaussian_decay", "exponential_decay"]:
-                if ref_point is None:
-                    raise ValueError(
-                        "When using SURFACE with scaling of correlation with "
-                        f"method {surface_scale.method}, "
-                        "the reference point must be specified."
-                    )
-
-        return values
 
     @validator("surface_scale", pre=True)
     def validate_surface_scale(cls, value):

--- a/tests/jobs/localisation/test_configs/test_config.py
+++ b/tests/jobs/localisation/test_configs/test_config.py
@@ -275,7 +275,13 @@ def test_simple_config_ref_point_error(ref_point, expected_error):
                 "param_group": {
                     "add": "PARAM_NODE1",
                 },
-                "ref_point": ref_point,
+                "field_scale": {
+                    "method": "gaussian_decay",
+                    "main_range": 1000,
+                    "perp_range": 1000,
+                    "azimuth": 200,
+                    "ref_point": ref_point,
+                },
             }
         ],
     }
@@ -434,36 +440,6 @@ def test_add_remove_obs_config(obs_group_add, obs_group_remove, expected):
 
 
 @pytest.mark.parametrize(
-    "ref_point",
-    [
-        [550, 1050],
-        [100, 150],
-        [0, 750],
-        [500, 750],
-        ["10", 1.0],
-    ],
-)
-def test_ref_point_config(ref_point):
-    data = {
-        "correlations": [
-            {
-                "name": "some_name",
-                "obs_group": {
-                    "add": "OBS",
-                },
-                "param_group": {
-                    "add": "PARAM_NODE1",
-                },
-                "ref_point": ref_point,
-            }
-        ],
-    }
-    conf = LocalisationConfig(observations=["OBS"], parameters=["PARAM_NODE1"], **data)
-    expected_refpoint = [float(item) for item in ref_point]
-    assert conf.correlations[0].ref_point == expected_refpoint
-
-
-@pytest.mark.parametrize(
     "pattern, list_of_words, expected_result",
     [(["*"], ["OBS_1", "2"], {"OBS_1", "2"}), ((["OBS*"], ["OBS_1", "2"], {"OBS_1"}))],
 )
@@ -545,7 +521,6 @@ def test_active_region_list(active_segment_list, scaling_factor_list, smooth_ran
                 "param_group": {
                     "add": ["*"],
                 },
-                "ref_point": [250, 250],
                 "field_scale": {
                     "method": "segment",
                     "segment_filename": "Region.GRDECL",
@@ -620,7 +595,6 @@ def test_active_region_list_mismatch(
                 "param_group": {
                     "add": ["*"],
                 },
-                "ref_point": [250, 250],
                 "field_scale": {
                     "method": "segment",
                     "segment_filename": "Region.GRDECL",
@@ -649,7 +623,6 @@ def test_invalid_keyword_errors_method_segment():
                 "param_group": {
                     "add": ["*"],
                 },
-                "ref_point": [250, 250],
                 "field_scale": {
                     "method": "segment",
                     "segment_filename": "Region.GRDECL",
@@ -680,7 +653,6 @@ def test_invalid_keyword_errors_method_from_file():
                 "param_group": {
                     "add": ["*"],
                 },
-                "ref_point": [250, 250],
                 "field_scale": {
                     "method": "from_file",
                     "segment_filename": "dummy.GRDECL",
@@ -709,7 +681,6 @@ def test_invalid_keyword_errors_in_obs_group_or_param_group():
                     "add": ["*"],
                     "unknown_param_keyword": "dummy",
                 },
-                "ref_point": [250, 250],
                 "field_scale": {
                     "method": "from_file",
                     "segment_filename": "dummy.GRDECL",
@@ -736,7 +707,6 @@ def test_missing_keyword_errors_method_gaussian_decay():
                 "param_group": {
                     "add": ["*"],
                 },
-                "ref_point": [250, 250],
                 "field_scale": {
                     "method": "gaussian_decay",
                     "main_range": 1000,

--- a/tests/jobs/localisation/test_integration.py
+++ b/tests/jobs/localisation/test_integration.py
@@ -180,12 +180,12 @@ def test_localisation_surf(
                 "param_group": {
                     "add": "*",
                 },
-                "ref_point": [250, 250],
                 "surface_scale": {
                     "method": "gaussian_decay",
                     "main_range": 1700,
                     "perp_range": 850,
                     "azimuth": 200,
+                    "ref_point": [250, 250],
                     "surface_file": "surf0.txt",
                 },
             },
@@ -249,12 +249,12 @@ def test_localisation_field1(
                 "param_group": {
                     "add": ["G1", "G2"],
                 },
-                "ref_point": [700, 370],
                 "field_scale": {
                     "method": "gaussian_decay",
                     "main_range": 1700,
                     "perp_range": 850,
                     "azimuth": 200,
+                    "ref_point": [700, 370],
                 },
             },
             {
@@ -265,12 +265,12 @@ def test_localisation_field1(
                 "param_group": {
                     "add": ["G3", "G4"],
                 },
-                "ref_point": [700, 370],
                 "field_scale": {
                     "method": "gaussian_decay",
                     "main_range": 1000,
                     "perp_range": 950,
                     "azimuth": 100,
+                    "ref_point": [700, 370],
                 },
             },
         ],
@@ -440,12 +440,12 @@ def test_localisation_field2(setup_poly_ert):
                 "param_group": {
                     "add": "FIELD1",
                 },
-                "ref_point": [500, 0],
                 "field_scale": {
                     "method": "gaussian_decay",
                     "main_range": 700,
                     "perp_range": 150,
                     "azimuth": 30,
+                    "ref_point": [500, 0],
                 },
             },
             {


### PR DESCRIPTION
Small modification of config file: Keyword ref_point is now put under keywords field_scale and surface_scale and only relevant for method: gaussian_decay and exponential_decay. Reference point data are now specified in class GaussianConfig.

The argument for doing this is:
1. Reference point is only relevant for scaling functions that actually use this, e.g. distance based localisation using gaussian_decay and exponential_decay. It is not relevant if scaling functions is defined outside ERT and imported or defined by segments.
2. There were no check telling the user that keyword ref_point was irrelevant for other methods than gaussian_decay, exponential_decay. 
3. The examples in documentation shows cases where ref_point was used but was irrelevant. This is fixed.

The original argument was that ref_point is logically related to observations, not to parameters, but it is relevant to say that reference point can be specified at other locations than at observation locations. For an injector / producer pair, the reference point should probably be located such that the area between the injector/producer pair where the sweep is most dominant is a good place for having the reference point to ensure that the correlations between field parameters an observations are not reduced too much in this area.