### PR TITLE
Unpin xlrd

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "pydantic",
         "scikit-learn",
         "scipy",
-        "xlrd<2",
+        "xlrd",
         "stea",
         "pyscal>=0.4.0",
         "fmu-ensemble",


### PR DESCRIPTION
solves #380 

`xlrd` `2.0.0` was released a year ago. The pinning of `xlrd` occured in https://github.com/equinor/semeio/pull/272, and `segyio` has been unpinned.

I think `xlrd` also had to be pinned in other libraries due its usage in `pandas`. I can't find the issue stating why `xlrd` had to be pinned though