### PR TITLE
Handle xlrd upgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "pydantic",
         "scikit-learn",
         "scipy",
-        "xlrd<2",
+        "xlrd",
         "stea",
         "pyscal>=0.4.0",
         "fmu-ensemble",

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,9 +1,9 @@
-pytest
+hypothesis
+odfpy
 openpyxl
-rstcheck
+pytest
 pytest-console-scripts
 pytest-httpserver
 pytest-snapshot
-hypothesis
+rstcheck
 xlwt
-odfpy

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,3 +5,5 @@ pytest-console-scripts
 pytest-httpserver
 pytest-snapshot
 hypothesis
+xlwt
+odfpy

--- a/tests/jobs/design2params/test_design2params.py
+++ b/tests/jobs/design2params/test_design2params.py
@@ -182,6 +182,22 @@ def test_three_column_defaults(tmpdir):
     assert (parsed_defaults.columns == ["keys", "defaults"]).all()
 
 
+@pytest.mark.parametrize(
+    "ext, engine", [("ods", "odf"), ("xls", "xlwt"), ("xlsx", None)]
+)
+def test_support_multiple_formats(tmp_path, ext, engine):
+    fname = tmp_path / ("test." + ext)
+    df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
+    df.to_excel(fname, sheet_name="TEST", index=False, engine=engine)
+    loaded_df = design2params._read_excel(
+        fname,
+        sheet_name="TEST",
+    )
+    loaded_df["col1"] = pd.to_numeric(loaded_df["col1"])
+    loaded_df["col2"] = pd.to_numeric(loaded_df["col2"])
+    pd.testing.assert_frame_equal(df, loaded_df, check_dtype=False)
+
+
 def test_run_realization_not_exist(input_data):
     with pytest.raises(SystemExit):
         design2params.run(


### PR DESCRIPTION
solves #380 

Manually verified that all tests pass with `xlrd == 1.2.0`

Otherwise we will get `pandas==1.1.5` in our pipeline (with py36) and `pandas==1.3.4` (with py38)
together with `xlrd == 2.0.1`