### PR TITLE
Remove deprecation warning from defaults-parsing

### DIFF
--- a/tests/jobs/design2params/test_design2params.py
+++ b/tests/jobs/design2params/test_design2params.py
@@ -164,11 +164,7 @@ def test_one_column_defaults(tmpdir):
 
 
 def test_three_column_defaults(tmpdir):
-    """
-    A deprecation warning will be emitted in this test.
-
-    Change this test later to assert the code will fail hard.
-    """
+    """Anything other than the two first columns is ignored"""
     # pylint: disable=abstract-class-instantiated
     tmpdir.chdir()
     write_design_xlsx(
@@ -178,8 +174,10 @@ def test_three_column_defaults(tmpdir):
     parsed_defaults = design2params._read_defaultssheet(
         "design_matrix.xlsx", "DefaultValues"
     )
-    assert len(parsed_defaults) == 1
-    assert (parsed_defaults.columns == ["keys", "defaults"]).all()
+    pd.testing.assert_frame_equal(
+        pd.DataFrame(columns=["keys", "defaults"], data=[["foo", "bar"]]),
+        parsed_defaults,
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Solves #384 

Ignore anything beyond the second column. The reason for the deprecation
warning was historic as there previously (pre-semeio) existed a version
of design2params that read the defaults in a transposed manner. Such
spreadsheets have probably not been in use since 2015, and it should be
safe now just to ignore these columns and continue as before.