### PR TITLE
Update design_kw to accept template files of type xml

### DIFF
--- a/semeio/jobs/design_kw/design_kw.py
+++ b/semeio/jobs/design_kw/design_kw.py
@@ -3,6 +3,8 @@ import logging
 import shlex
 import re
 
+from typing import List
+
 
 _STATUS_FILE_NAME = "DESIGN_KW.OK"
 
@@ -61,6 +63,13 @@ def all_matched(line, template_file_name, template):
                     f"but this is probably a Perl file"
                 )
             )
+        elif is_xml(template_file_name, template):
+            _logger.warning(  # pylint: disable=logging-fstring-interpolation
+                (
+                    f"{unmatched} not found in design matrix, "
+                    f"but this is probably an xml file"
+                )
+            )
         else:
             _logger.error(  # pylint: disable=logging-fstring-interpolation
                 f"{unmatched} not found in design matrix"
@@ -71,6 +80,10 @@ def all_matched(line, template_file_name, template):
 
 def is_perl(file_name, template):
     return file_name.endswith(".pl") or template[0].find("perl") != -1
+
+
+def is_xml(file_name: str, template: List[str]):
+    return file_name.endswith(".xml") or template[0].find("?xml") != -1
 
 
 def unmatched_templates(line):

--- a/tests/jobs/design_kw/data/parameters_for_xml_case.txt
+++ b/tests/jobs/design_kw/data/parameters_for_xml_case.txt
@@ -1,0 +1,16 @@
+prob_FP_FP   0.9
+prob_CH_FP  0.0
+prob_CR_FP  0.05
+prob_CO_FP  0.05
+prob_FP_CH   0.1
+prob_CH_CH  0.85
+prob_CR_CH  0.05
+prob_CO_CH  0.0
+prob_FP_CR   0.1
+prob_CH_CR  0.1
+prob_CR_CR   0.75
+prob_CO_CR   0.05
+prob_FP_CO   0.05
+prob_CH_CO  0.0
+prob_CR_CO 0.05
+prob_CO_CO 0.90

--- a/tests/jobs/design_kw/data/template_xml_format.reference
+++ b/tests/jobs/design_kw/data/template_xml_format.reference
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+<APS_prob_trend>
+  <FaciesProbTrend>
+    <GridModelName>   geogrid </GridModelName>
+    <ZoneParamName>  Zone </ZoneParamName>
+    <FaciesParamName>  Facies_true_model </FaciesParamName>
+    <ProbParamNamePrefix>  ProbTrend  </ProbParamNamePrefix>
+    <SelectedZones> 1 2 3 </SelectedZones>
+    <UseConstantProbFromVolumeFraction> 1 </UseConstantProbFromVolumeFraction>
+    <CondProbMatrix>
+      <Line>  Floodplain  Floodplain  0.9 </Line>
+      <Line>  Channel     Floodplain   0.0  </Line>
+      <Line>  Crevasse    Floodplain  0.05  </Line>
+      <Line>  Coal        Floodplain      0.05  </Line>
+
+      <Line>  Floodplain  Channel  0.1   </Line>
+      <Line>  Channel     Channel   0.85  </Line>
+      <Line>  Crevasse    Channel  0.05   </Line>
+      <Line>  Coal        Channel     0.0   </Line>
+
+      <Line>  Floodplain  Crevasse  0.1  </Line>
+      <Line>  Channel     Crevasse   0.1 </Line>
+      <Line>  Crevasse    Crevasse  0.75  </Line>
+      <Line>  Coal        Crevasse      0.05  </Line>
+
+      <Line>  Floodplain  Coal  0.05  </Line>
+      <Line>  Channel     Coal   0.0 </Line>
+      <Line>  Crevasse    Coal  0.05 </Line>
+      <Line>  Coal        Coal     0.90  </Line>
+    </CondProbMatrix>
+  </FaciesProbTrend>
+</APS_prob_trend>

--- a/tests/jobs/design_kw/data/template_xml_format.tmpl
+++ b/tests/jobs/design_kw/data/template_xml_format.tmpl
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+<APS_prob_trend>
+  <FaciesProbTrend>
+    <GridModelName>   geogrid </GridModelName>
+    <ZoneParamName>  Zone </ZoneParamName>
+    <FaciesParamName>  Facies_true_model </FaciesParamName>
+    <ProbParamNamePrefix>  ProbTrend  </ProbParamNamePrefix>
+    <SelectedZones> 1 2 3 </SelectedZones>
+    <UseConstantProbFromVolumeFraction> 1 </UseConstantProbFromVolumeFraction>
+    <CondProbMatrix>
+      <Line>  Floodplain  Floodplain  <prob_FP_FP> </Line>
+      <Line>  Channel     Floodplain   <prob_CH_FP>  </Line>
+      <Line>  Crevasse    Floodplain  <prob_CR_FP>  </Line>
+      <Line>  Coal        Floodplain      <prob_CO_FP>  </Line>
+
+      <Line>  Floodplain  Channel  <prob_FP_CH>   </Line>
+      <Line>  Channel     Channel   <prob_CH_CH>  </Line>
+      <Line>  Crevasse    Channel  <prob_CR_CH>   </Line>
+      <Line>  Coal        Channel     <prob_CO_CH>   </Line>
+
+      <Line>  Floodplain  Crevasse  <prob_FP_CR>  </Line>
+      <Line>  Channel     Crevasse   <prob_CH_CR> </Line>
+      <Line>  Crevasse    Crevasse  <prob_CR_CR>  </Line>
+      <Line>  Coal        Crevasse      <prob_CO_CR>  </Line>
+
+      <Line>  Floodplain  Coal  <prob_FP_CO>  </Line>
+      <Line>  Channel     Coal   <prob_CH_CO> </Line>
+      <Line>  Crevasse    Coal  <prob_CR_CO> </Line>
+      <Line>  Coal        Coal     <prob_CO_CO>  </Line>
+    </CondProbMatrix>
+  </FaciesProbTrend>
+</APS_prob_trend>

--- a/tests/jobs/design_kw/test_design_kw.py
+++ b/tests/jobs/design_kw/test_design_kw.py
@@ -190,19 +190,54 @@ def test_is_perl():
     assert not design_kw.is_perl(file_name, template)
 
 
+def test_is_xml():
+    file_name = "filename.yml"
+    template = ["?xml", "  ECLIPSE_INIT_DATE: <DATE>"]
+    assert design_kw.is_xml(file_name, template)
+
+    file_name = "filename.xml"
+    template = ["?xml", "  ECLIPSE_INIT_DATE: <DATE>"]
+    assert design_kw.is_xml(file_name, template)
+
+    file_name = "filename.xml"
+    template = ["  ECLIPSE_INIT_DATE: <DATE>"]
+    assert design_kw.is_xml(file_name, template)
+
+    file_name = "filename.yml"
+    template = ["  ECLIPSE_INIT_DATE: <DATE>"]
+    assert not design_kw.is_xml(file_name, template)
+
+
 @pytest.mark.parametrize(
     "filenames",
     (
-        ["template.yml.reference", "template.yml.tmpl", "template.yml"],
-        ["schfile.inc.reference", "schfile.inc.tmpl", "schfile.inc"],
+        [
+            "template.yml.reference",
+            "template.yml.tmpl",
+            "template.yml",
+            "parameters.txt",
+        ],
+        ["schfile.inc.reference", "schfile.inc.tmpl", "schfile.inc", "parameters.txt"],
+        [
+            "template_xml_format.reference",
+            "template_xml_format.tmpl",
+            "template_xml_format.xml",
+            "parameters_for_xml_case.txt",
+        ],
     ),
 )
 def test_run(input_data, filenames):
     reference_filename = filenames[0]
     template_filename = filenames[1]
     result_filename = filenames[2]
+    parameter_filename = filenames[3]
 
-    design_kw.run(template_filename, result_filename, log_level=logging.DEBUG)
+    design_kw.run(
+        template_filename,
+        result_filename,
+        log_level=logging.DEBUG,
+        parameters_file_name=parameter_filename,
+    )
 
     with open(result_filename, "r", encoding="utf-8") as result_file:
         result = result_file.read()


### PR DESCRIPTION
Purpose: Sometimes it is useful to apply scripts that have xml files as model files. A template file for an xml model file has lots of keywords in <> parenthesis. But validation check in design_kw.py will fail for template files for xml model files. An exception where errors are replaced by warnings is implemented for template files of type xml. 