### PR TITLE
Dont check the formatting of the ert log

### DIFF
--- a/tests/jobs/csv_export2/test_integration.py
+++ b/tests/jobs/csv_export2/test_integration.py
@@ -267,7 +267,7 @@ def test_ert_integration_errors(norne_mocked_ensembleset, snapshot):
             break
     with open(log_file) as fin:
         ertlog = fin.read()
-    assert "fmu.ensemble.realization - WARNING - No STATUS file" in ertlog
+    assert "No STATUS file" in ertlog
     assert "realization-2/iter-0" in ertlog
 
     assert os.path.exists("data.csv")


### PR DESCRIPTION
This is still probably testing to much, but will leave it here now. Should this
happen again in the future it is probably safe to just remove the checks on the
log.