### PR TITLE
Fix reference to <RUNPATH_FILE> magic string in CSV_EXPORT2

### DIFF
--- a/semeio/workflows/csv_export2/csv_export2.py
+++ b/semeio/workflows/csv_export2/csv_export2.py
@@ -118,7 +118,7 @@ def csv_export_parser():
         type=str,
         help=(
             "Path to ERT RUNPATH-file, "
-            "usually the ERT magic variable <RUNPATH> can be used"
+            "usually the ERT magic variable <RUNPATH_FILE> can be used"
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
The CSV_EXPORT2 job erroneously referenced the <RUNPATH> magic string which will point to the runpath of a job.

The <RUNPATH_FILE> points to the file in question.