### PR TITLE
Import MeasuredData through ert

### DIFF
--- a/semeio/workflows/correlated_observations_scaling/cos.py
+++ b/semeio/workflows/correlated_observations_scaling/cos.py
@@ -4,7 +4,7 @@ import logging
 import yaml
 import configsuite
 
-from ert_data.measured import MeasuredData
+from ert import MeasuredData
 from ert_shared.libres_facade import LibresFacade
 from ert_shared.plugins.plugin_manager import hook_implementation
 from semeio.communication import SemeioScript

--- a/semeio/workflows/misfit_preprocessor/misfit_preprocessor.py
+++ b/semeio/workflows/misfit_preprocessor/misfit_preprocessor.py
@@ -1,6 +1,6 @@
 import yaml
 
-from ert_data.measured import MeasuredData
+from ert import MeasuredData
 from ert_shared.libres_facade import LibresFacade
 from ert_shared.plugins.plugin_manager import hook_implementation
 

--- a/semeio/workflows/spearman_correlation_job/spearman_correlation.py
+++ b/semeio/workflows/spearman_correlation_job/spearman_correlation.py
@@ -1,6 +1,6 @@
 import argparse
 
-from ert_data.measured import MeasuredData
+from ert import MeasuredData
 from ert_shared.libres_facade import LibresFacade
 from ert_shared.plugins.plugin_manager import hook_implementation
 from semeio.communication import SemeioScript


### PR DESCRIPTION
The ert import structure is going to change to conform to pep8's
"modules should explicitly declare the names in their public API using
the `__all__` attribute. [...] Other modules must not rely on indirect
access to such imported names unless they are an explicitly documented
part of the containing module's API, such as os.path".