### PR TITLE
Pin ert

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
     install_requires=[
         "ecl",
-        "ert >= 2.36.0b0",
+        "ert >= 2.38.0b0",
         "configsuite>=0.6",
         "numpy",
         "pandas>1.3.0",


### PR DESCRIPTION
Ert is applying breaking changes. Current version will only
work with 2.38.0b0 until breakage is resolved.