### PR TITLE
Move to use oil_reservoir_synthesizer

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,6 @@
 hypothesis
 odfpy
+oil_reservoir_synthesizer
 openpyxl
 pytest
 pytest-console-scripts

--- a/tests/legacy_test_data/snake_oil/jobs/snake_oil_simulator.py
+++ b/tests/legacy_test_data/snake_oil/jobs/snake_oil_simulator.py
@@ -4,8 +4,7 @@
 from datetime import datetime
 
 from ecl.summary import EclSum
-
-from res.test.synthesizer import OilSimulator
+from oil_reservoir_synthesizer import OilSimulator
 
 
 def globalIndex(i, j, k, nx=10, ny=10, nz=10):
@@ -23,7 +22,6 @@ def readParameters(filename):
 
 
 def runSimulator(simulator, history_simulator, time_step_count):
-    """@rtype: EclSum"""
     ecl_sum = EclSum.writer("SNAKE_OIL_FIELD", datetime(2010, 1, 1), 10, 10, 10)
 
     ecl_sum.addVariable("FOPT")


### PR DESCRIPTION
ert will remove `res.test.synthesizer`. This functionality now resides in the new package `oil_reservoir_synthesizer` instead.