### PR TITLE
Remove usage of EnKFMain in spearman test

### DIFF
--- a/semeio/communication/semeio_script.py
+++ b/semeio/communication/semeio_script.py
@@ -71,7 +71,7 @@ class SemeioScript(ErtScript):  # pylint: disable=too-few-public-methods
             thread_id = threading.get_ident()
             report_handler = _ReportHandler(self._output_dir, thread_id)
             with _LogHandlerContext(log, report_handler):
-                self._real_run(*args, **kwargs)
+                return self._real_run(*args, **kwargs)
 
         self.run = MethodType(run_with_handler, self)
 

--- a/semeio/workflows/spearman_correlation_job/spearman_correlation.py
+++ b/semeio/workflows/spearman_correlation_job/spearman_correlation.py
@@ -37,6 +37,7 @@ class SpearmanCorrelationJob(SemeioScript):
                 CorrelatedObservationsScalingJob(self.ert()).run(scaling_configs)
             except EmptyDatasetException:
                 pass
+        return self._output_dir
 
 
 def spearman_job_parser():


### PR DESCRIPTION
This changes the definition of SpearManCorrelationJob to return the output directory to make this observable by the test without looking at internals. I believe this is ok.