### PR TITLE
Use release candidates of ert in CI testing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,7 +27,9 @@ jobs:
           python-version: "${{ matrix.python-version }}"
 
       - name: "Install dependencies"
-        run: python -m pip install tox tox-gh-actions
+        run: |
+          pip install -U --pre ert
+          pip install tox tox-gh-actions
 
       - name: "Run tox targets on ${{ matrix.os }} for ${{ matrix.python-version }}"
         run: "python -m tox"


### PR DESCRIPTION
This will allow PR's that depend on release candidates of ert to pass testing.