### PR TITLE
Remove check for empty observation vectors

### DIFF
--- a/semeio/workflows/correlated_observations_scaling/cos.py
+++ b/semeio/workflows/correlated_observations_scaling/cos.py
@@ -12,7 +12,6 @@ from semeio.workflows.correlated_observations_scaling import (
     job_config,
 )
 from semeio.workflows.correlated_observations_scaling.job_config import ObsCorrConfig
-from semeio.workflows.correlated_observations_scaling.obs_utils import keys_with_data
 from semeio.workflows.correlated_observations_scaling.update_scaling import (
     scale_observations,
 )
@@ -142,18 +141,12 @@ class CorrelatedObservationsScalingJob(SemeioScript):
 
         obs = self.facade.get_observations()
         obs_keys = [self.facade.get_observation_key(nr) for nr, _ in enumerate(obs)]
-        obs_with_data = keys_with_data(
-            obs,
-            obs_keys,
-            self.facade.get_ensemble_size(),
-            self.facade.get_current_fs(),
-        )
         default_values = _get_default_values(
             self.facade.get_alpha(), self.facade.get_std_cutoff()
         )
         for config_dict in user_config:
             config = ObsCorrConfig(config_dict, obs_keys, default_values)
-            config.validate(obs_with_data)
+            config.validate()
 
             measured_data = _get_measured_data(
                 self.facade,

--- a/semeio/workflows/correlated_observations_scaling/job_config.py
+++ b/semeio/workflows/correlated_observations_scaling/job_config.py
@@ -232,12 +232,12 @@ class ObsCorrConfig:
         self.config = self._setup_configuration()
         self.errors = []
 
-    def validate(self, obs_with_data):
+    def validate(self):
         """
         Validates the full configuration. If invalid, raises an ValidationError.
         """
         self._schema_validation()
-        self._context_validation(obs_with_data)
+        self._context_validation()
 
         if len(self.errors) > 0:
             raise ValidationError("Invalid job", self.errors)
@@ -245,7 +245,7 @@ class ObsCorrConfig:
     def _schema_validation(self):
         self.errors.extend(list(self.config.errors))
 
-    def _context_validation(self, obs_with_data):
+    def _context_validation(self):
         config = self.config.snapshot
         calc_keys = [event.key for event in config.CALCULATE_KEYS.keys]
         application_keys = [entry.key for entry in config.UPDATE_KEYS.keys]
@@ -253,7 +253,6 @@ class ObsCorrConfig:
         self.errors.extend(
             has_keys(self._obs_keys, calc_keys, "Key: {} has no observations")
         )
-        self.errors.extend(has_keys(obs_with_data, calc_keys, "Key: {} has no data"))
 
     def _setup_configuration(self):
         """

--- a/semeio/workflows/correlated_observations_scaling/obs_utils.py
+++ b/semeio/workflows/correlated_observations_scaling/obs_utils.py
@@ -2,8 +2,7 @@ import fnmatch
 from collections import namedtuple
 from copy import deepcopy
 
-from ecl.util.util import BoolVector
-from ert._c_wrappers.enkf import ActiveList, RealizationStateEnum
+from ert._c_wrappers.enkf import ActiveList
 
 from semeio.workflows.correlated_observations_scaling.exceptions import ValidationError
 
@@ -104,19 +103,6 @@ def _active_list_from_index_list(index_list):
     for index in index_list:
         active_list.addActiveIndex(index)
     return active_list
-
-
-def keys_with_data(observations, keys, ensemble_size, storage):
-    """
-    Checks that all keys have data and returns a list of error messages
-    """
-    active_realizations = storage.realizationList(RealizationStateEnum.STATE_HAS_DATA)
-
-    if len(active_realizations) == 0:
-        return []
-
-    active_mask = BoolVector.createFromList(ensemble_size, active_realizations)
-    return [key for key in keys if observations[key].hasData(active_mask, storage)]
 
 
 def _data_index_to_obs_index(obs, obs_key, data_index_list):

--- a/tests/jobs/correlated_observations_scaling/unit/test_obs_util.py
+++ b/tests/jobs/correlated_observations_scaling/unit/test_obs_util.py
@@ -12,7 +12,6 @@ from semeio.workflows.correlated_observations_scaling.obs_utils import (
     _wildcard_to_dict_list,
     create_active_lists,
     find_and_expand_wildcards,
-    keys_with_data,
 )
 
 
@@ -176,24 +175,3 @@ def test_add_observation_vectors(test_data_root):
 
     assert "WOPR_OP1_108" in keys
     assert "WOPR_OP1_144" not in keys
-
-
-@pytest.mark.usefixtures("setup_tmpdir")
-def test_validate_no_realizations(test_data_root):
-    """
-    Ensamble has not run
-    """
-    test_data_dir = os.path.join(test_data_root, "poly_normal")
-    shutil.copytree(test_data_dir, "test_data")
-    os.chdir(os.path.join("test_data"))
-
-    ert = LibresFacade.from_config_file("poly.ert")
-    observations = ert.get_observations()
-
-    result = keys_with_data(
-        observations,
-        ["POLY_OBS"],
-        ert.get_ensemble_size(),
-        ert.get_current_fs(),
-    )
-    assert result == []

--- a/tests/jobs/correlated_observations_scaling/unit/test_scaling_job.py
+++ b/tests/jobs/correlated_observations_scaling/unit/test_scaling_job.py
@@ -71,30 +71,20 @@ def test_config_value_overwrites_default(input_key):
 
 @pytest.mark.parametrize("alpha", [True, False])
 @pytest.mark.parametrize(
-    "calc_key,app_key,obs_keys,obs_with_data,errors",
+    "calc_key,app_key,obs_keys,errors",
     [
-        (
-            "KEY_1",
-            "KEY_1",
-            ["KEY_1", "KEY_2"],
-            ["KEY_2"],
-            ["Key: KEY_1 has no data"],
-        ),
         (
             "not_in_list",
             "KEY_1",
             ["KEY_1"],
-            ["KEY_1"],
             [
                 "Update key: KEY_1 missing from calculate keys: ['not_in_list']",
                 "Key: not_in_list has no observations",
-                "Key: not_in_list has no data",
             ],
         ),
         (
             "KEY_1",
             "not_in_list",
-            ["KEY_1"],
             ["KEY_1"],
             ["Update key: not_in_list missing from calculate keys: ['KEY_1']"],
         ),
@@ -102,10 +92,8 @@ def test_config_value_overwrites_default(input_key):
             "KEY_1",
             "KEY_1",
             [],
-            ["KEY_1"],
             ["Key: KEY_1 has no observations"],
         ),
-        ("KEY_1", "KEY_1", ["KEY_1"], [], ["Key: KEY_1 has no data"]),
     ],
 )
 @pytest.mark.usefixtures("setup_tmpdir")
@@ -113,7 +101,6 @@ def test_invalid_job(
     calc_key,
     app_key,
     obs_keys,
-    obs_with_data,
     errors,
     alpha,
 ):
@@ -133,5 +120,5 @@ def test_invalid_job(
         )
 
     with pytest.raises(ValidationError) as exc_info:
-        ObsCorrConfig(user_config_dict, obs_keys, {}).validate(obs_with_data)
+        ObsCorrConfig(user_config_dict, obs_keys, {}).validate()
     assert [str(elem) for elem in exc_info.value.errors] == errors


### PR DESCRIPTION
If no response can be loaded an error message will be raised from ert, meaning that this check is redundant.