### PR TITLE
Update usage of xtgeo, avoid warning

### DIFF
--- a/tests/jobs/localisation/test_integration.py
+++ b/tests/jobs/localisation/test_integration.py
@@ -334,8 +334,7 @@ def create_box_grid_with_inactive_and_active_cells(
         for i in range(5):
             fout.write(f" {x[i]}  {y[i]}  {zinc}\n")
 
-    polygon = xtgeo.xyz.Polygons()
-    polygon.from_file("polygon.txt", fformat="xyz")
+    polygon = xtgeo.polygons_from_file("polygon.txt", fformat="xyz")
     if has_inactive_values:
         grid.inactivate_outside(polygon, force_close=True)
 


### PR DESCRIPTION
```
  /mnt/scratch/f_scout_ci/actions-runner-05/_temp/test_root/tests/jobs/localisation/test_integration.py:338: DeprecatedWarning: from_file is deprecated as of 2.21 and will be removed in 4.0. Use xtgeo.polygons_from_file() instead
    polygon.from_file("polygon.txt", fformat="xyz")
```