### PR TITLE
Use 32-bit integers due to xtgeo

### DIFF
--- a/semeio/workflows/localisation/local_script_lib.py
+++ b/semeio/workflows/localisation/local_script_lib.py
@@ -304,7 +304,7 @@ def define_look_up_index(user_defined_active_region_list, max_region_number):
     corresponding to the region number.
     """
     active_segment_array = np.array(user_defined_active_region_list)
-    index_per_used_region = ma.zeros((max_region_number + 1), dtype=np.uint16)
+    index_per_used_region = ma.zeros((max_region_number + 1), dtype=np.int32)
     index_values = np.arange(len(active_segment_array))
     index_per_used_region[active_segment_array[index_values]] = index_values
     return index_per_used_region
@@ -508,9 +508,8 @@ def read_region_files_for_all_correlation_groups(user_config, grid):
                             strict=True,
                             ecl_type=EclDataType.ECL_INT,
                         )
-                    # Ensure the region_parameter is a numpy 1D array of uint16
-                    region_parameter = np.zeros(nx * ny * nz, dtype=np.uint16)
-                    not_active = np.zeros(nx * ny * nz, dtype=np.uint16)
+                    region_parameter = np.zeros(nx * ny * nz, dtype=np.int32)
+                    not_active = np.zeros(nx * ny * nz, dtype=np.int32)
                     for k, j, i in itertools.product(range(nz), range(ny), range(nx)):
                         index = i + j * nx + k * nx * ny
                         v = region_parameter_read[i, j, k]

--- a/tests/jobs/localisation/test_integration.py
+++ b/tests/jobs/localisation/test_integration.py
@@ -358,10 +358,10 @@ def create_region_parameter(filename, grid):
     region_param = xtgeo.GridProperty(
         grid, name=region_param_name, discrete=True, values=1
     )
-    region_param.dtype = np.uint16
+    region_param.dtype = np.int32
     region_param.codes = region_code_names
     (nx, ny, nz) = grid.dimensions
-    values = np.zeros((nx, ny, nz), dtype=np.uint16)
+    values = np.zeros((nx, ny, nz), dtype=np.int32)
     values[:, :, :] = 0
     for k, j, i in itertools.product(range(nz), range(ny), range(nx)):
         if 0 <= i <= nx / 2 and 0 <= j <= ny / 2:


### PR DESCRIPTION
Usage of uint16 is a valid optimization for the region parameter, but xtgeo is using numpy with a fill value that overflows in uint16.

As long as xtgeo does not support uint16 explicitly, we need to resort to 32-bits.

https://github.com/equinor/xtgeo/blob/69becba852ace157c8610f9b2edcfb582e7d96f9/src/xtgeo/common/constants.py#L13

This triggers a warning from numpy stating that this condition will lead to an error in the future