### PR TITLE
Resolve pytest warning on PytestUnknownMarkWarning

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -1,6 +1,7 @@
 
 copy_test_files () {
     cp -r $CI_SOURCE_ROOT/tests $CI_TEST_ROOT/tests
+    cp $CI_SOURCE_ROOT/pyproject.toml $CI_TEST_ROOT
 }
 
 start_tests () {


### PR DESCRIPTION
When running tests through komodo, pytest claims ert_integration is an unknown mark. This is probably due to pyproject.toml, which defines it, is not present where it is running the tests