### PR TITLE
Pin rstcheck-core because of pydantic issues

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,5 +6,5 @@ pytest
 pytest-console-scripts
 pytest-httpserver
 pytest-snapshot
-rstcheck-core
+rstcheck-core<=1.0.3
 xlwt


### PR DESCRIPTION
Although ert requires pydantic<2. Installing test-requirements.txt after installing ert means you get pydantic v2 due to rstcheck-core.