### PR TITLE
Don't import from top-level ert module

### DIFF
--- a/src/semeio/communication/semeio_script.py
+++ b/src/semeio/communication/semeio_script.py
@@ -6,7 +6,8 @@ from logging.handlers import BufferingHandler
 from pathlib import Path
 from types import MethodType
 
-from ert import ErtScript, LibresFacade
+from ert.config import ErtScript
+from ert.libres_facade import LibresFacade
 
 from semeio.communication.reporter import FileReporter
 

--- a/src/semeio/workflows/csv_export2/csv_export2.py
+++ b/src/semeio/workflows/csv_export2/csv_export2.py
@@ -2,7 +2,7 @@ import argparse
 import sys
 
 import pandas as pd
-from ert import ErtScript
+from ert.config import ErtScript
 from ert.shared.plugins.plugin_manager import hook_implementation
 from fmu import ensemble
 

--- a/src/semeio/workflows/misfit_preprocessor/misfit_preprocessor.py
+++ b/src/semeio/workflows/misfit_preprocessor/misfit_preprocessor.py
@@ -1,6 +1,6 @@
 import logging
 
-from ert import ErtScript
+from ert.config import ErtScript
 from ert.shared.plugins.plugin_manager import hook_implementation
 
 logger = logging.getLogger(__name__)

--- a/tests/workflows/ahm_analysis/test_integration.py
+++ b/tests/workflows/ahm_analysis/test_integration.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
-from ert import LibresFacade
+from ert.libres_facade import LibresFacade
 from ert.storage import open_storage
 
 from semeio._exceptions.exceptions import ValidationError

--- a/tests/workflows/conftest.py
+++ b/tests/workflows/conftest.py
@@ -2,7 +2,7 @@ import os
 import shutil
 
 import pytest
-from ert import LibresFacade
+from ert.libres_facade import LibresFacade
 
 
 @pytest.fixture()

--- a/tests/workflows/localisation/test_integration.py
+++ b/tests/workflows/localisation/test_integration.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import xtgeo
 import yaml
-from ert import LibresFacade
+from ert.libres_facade import LibresFacade
 from ert.storage import open_storage
 from xtgeo.surface.regular_surface import RegularSurface
 


### PR DESCRIPTION
This is to speed up importing selected submodules of `ert`.