### PR TITLE
Add TMPDIR to environment passed to ERT in integration test

### DIFF
--- a/tests/communication/test_integration.py
+++ b/tests/communication/test_integration.py
@@ -21,7 +21,7 @@ def test_semeio_script_integration(tmpdir):
 
     ert_env = {
         env_var: os.environ[env_var]
-        for env_var in ("PATH", "LD_LIBRARY_PATH")
+        for env_var in ("PATH", "LD_LIBRARY_PATH", "TMPDIR")
         if env_var in os.environ
     }
     ert_env["PYTHONPATH"] = os.pathsep.join(map(os.path.realpath, sys.path))


### PR DESCRIPTION
If TMPDIR is set to anything but /tmp, then ert will currently leave behind a folder in /tmp due to not beeing passed the TMPDIR environment variable.