### PR TITLE
Have CSV_EXPORT raise warning on no data

### DIFF
--- a/src/semeio/workflows/csv_export2/csv_export2.py
+++ b/src/semeio/workflows/csv_export2/csv_export2.py
@@ -79,11 +79,11 @@ def csv_exporter(runpathfile, time_index, outputfile, column_keys=None):
     ensemble_set = ensemble.EnsembleSet(
         name="ERT EnsembleSet for CSV_EXPORT2", runpathfile=runpathfile
     )
-    summary = ensemble_set.load_smry(time_index=time_index, column_keys=column_keys)
-    try:  # try/except is needed for fmu-ensemble<=1.3.0
+    try:
+        summary = ensemble_set.load_smry(time_index=time_index, column_keys=column_keys)
         parameters = ensemble_set.parameters
-    except KeyError:
-        parameters = pd.DataFrame()
+    except KeyError as exc:
+        raise UserWarning("No data found") from exc
 
     if not parameters.empty:
         pd.merge(summary, parameters).to_csv(outputfile, index=False)

--- a/tests/workflows/csv_export2/test_integration.py
+++ b/tests/workflows/csv_export2/test_integration.py
@@ -84,13 +84,24 @@ def test_that_iterations_in_runpathfile_cannot_be_defaulted():
         "000 real0 NORNE_0\n001 real1 NORNE_1\n", encoding="utf-8"
     )
 
-    with pytest.raises(KeyError):
+    with pytest.raises(UserWarning):
         csv_export2.csv_exporter(
             runpathfile="runpathfile",
             time_index="yearly",
             outputfile="unsmry--yearly.csv",
             column_keys=["F?PT"],
         )
+
+
+def test_empty_file_yields_user_warning():
+    with open("empty_file", "a", encoding="utf-8") as empty_file:
+        with pytest.raises(UserWarning, match="No data found"):
+            csv_export2.csv_exporter(
+                runpathfile=empty_file.name,
+                time_index="raw",
+                outputfile="unsmry--yearly.csv",
+                column_keys=["*"],
+            )
 
 
 @pytest.mark.parametrize("input_rst", [csv_export2.DESCRIPTION, csv_export2.EXAMPLES])


### PR DESCRIPTION
Resolves #584 

The CSV_EXPORT job raises KeyError if no data for no realizations.

https://github.com/equinor/fmu-ensemble/blob/5c39d6f10d93523da65f7314e559ae74a53d15cf/src/fmu/ensemble/ensemble.py#L693
