### PR TITLE
Add pytest-xdist to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ test = [
     "pytest",
     "pytest-console-scripts",
     "pytest-snapshot",
+    "pytest-xdist",
     "rstcheck-core",
     "xlwt",
     "mypy",


### PR DESCRIPTION
This suspect this requires pytest-xdist

```
+ pushd /tmp/f_scout_ci/actions-runner-02/_temp/test_root
+ start_tests
+ pytest -n auto --ert-integration
/tmp/f_scout_ci/actions-runner-02/_temp/test_root /tmp/f_scout_ci/actions-runner-02/_temp/source_root /tmp/f_scout_ci/actions-runner-02/_temp /tmp/f_scout_ci/actions-runner-02/komodo-releases/komodo-releases
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: -n
```
https://github.com/equinor/komodo-releases/actions/runs/9457497222/job/26052100076