### PR TITLE
Fix `DESIGN_KW` validation flag bug

### DIFF
--- a/src/semeio/forward_models/__init__.py
+++ b/src/semeio/forward_models/__init__.py
@@ -47,7 +47,12 @@ class DesignKW(ForwardModelStepPlugin):
     def __init__(self):
         super().__init__(
             name="DESIGN_KW",
-            command=["design_kw", "<template_file>", "<result_file>", "<VALIDATE>"],
+            command=[
+                "design_kw",
+                "<template_file>",
+                "<result_file>",
+                "--validate=<VALIDATE>",
+            ],
             default_mapping={"<VALIDATE>": "false"},
         )
 

--- a/src/semeio/forward_models/scripts/design_kw.py
+++ b/src/semeio/forward_models/scripts/design_kw.py
@@ -46,7 +46,7 @@ def create_parser():
         default="WARNING",
         type=logging.getLevelName,
     )
-    parser.add_argument("--validate", required=False, type=bool, default=False)
+    parser.add_argument("--validate", required=False, type=str, default="false")
     return parser
 
 


### PR DESCRIPTION
This commit fixes the issue where the `<VALIDATE>=true` argument would be parsed as a positional argument instead of a keyword argument, and the arg parsed would raise an exception for unexpected argument `false`. After this commit, the <VALIDATE> argument is only for ert validation purposes, and is not forwarded to the `DESIGN_KW` argparser.