### PR TITLE
Add Iman-Conover transformation

### DIFF
--- a/src/semeio/fmudesign/__init__.py
+++ b/src/semeio/fmudesign/__init__.py
@@ -8,13 +8,14 @@ Output of this module can be used in custom standalone applications.
 from semeio.fmudesign._designsummary import summarize_design
 from semeio.fmudesign._excel2dict import excel2dict_design, inputdict_to_yaml
 from semeio.fmudesign._tornado_onebyone import calc_tornadoinput
-from semeio.fmudesign.create_design import DesignMatrix, iman_conover
+from semeio.fmudesign.create_design import DesignMatrix
+from semeio.fmudesign.iman_conover import ImanConover
 
 __all__ = [
     "summarize_design",
     "calc_tornadoinput",
     "DesignMatrix",
-    "iman_conover",
+    "ImanConover",
     "excel2dict_design",
     "inputdict_to_yaml",
 ]

--- a/src/semeio/fmudesign/iman_conover.py
+++ b/src/semeio/fmudesign/iman_conover.py
@@ -1,0 +1,245 @@
+"""
+An implementation of the Iman-Conover transformation.
+
+Using Iman-Conover with Latin Hybercube sampling
+------------------------------------------------
+
+Sample on the unit hypercube using LatinHypercube
+
+>>> import scipy as sp
+>>> sampler = sp.stats.qmc.LatinHypercube(d=2, seed=42, scramble=True)
+>>> samples = sampler.random(n=100)
+
+Map to distributions
+
+>>> X = np.vstack((sp.stats.triang(0.5).ppf(samples[:, 0]),
+...                sp.stats.gamma.ppf(samples[:, 1], a=1))).T
+
+Induce correlations
+
+>>> sp.stats.pearsonr(*X.T).statistic
+0.06589800321227991
+>>> correlation_matrix = np.array([[1, 0.3], [0.3, 1]])
+>>> transform = ImanConover(correlation_matrix)
+>>> X_transformed = transform(X)
+>>> sp.stats.pearsonr(*X_transformed.T).statistic
+0.27965286549530805
+"""
+
+import numpy as np
+import scipy as sp
+
+
+def _is_positive_definite(X):
+    try:
+        np.linalg.cholesky(X)
+        return True
+    except np.linalg.LinAlgError:
+        return False
+
+
+class ImanConover:
+    def __init__(self, correlation_matrix):
+        """Create an Iman-Conover transform.
+
+        Parameters
+        ----------
+        correlation_matrix : ndarray
+            Target correlation matrix of shape (K, K). The Iman-Conover will
+            try to induce a correlation on the data set X so that corr(X) is
+            as close to `correlation_matrix` as possible.
+
+        Notes
+        -----
+        The implementation follows the original paper:
+        Iman, R. L., & Conover, W. J. (1982). A distribution-free approach to
+        inducing rank correlation among input variables. Communications in
+        Statistics - Simulation and Computation, 11(3), 311-334.
+        https://www.tandfonline.com/doi/epdf/10.1080/03610918208812265?needAccess=true
+        https://www.uio.no/studier/emner/matnat/math/STK4400/v05/undervisningsmateriale/A%20distribution-free%20approach%20to%20rank%20correlation.pdf
+
+        Other useful sources:
+        - https://blogs.sas.com/content/iml/2021/06/16/geometry-iman-conover-transformation.html
+        - https://blogs.sas.com/content/iml/2021/06/14/simulate-iman-conover-transformation.html
+        - https://aggregate.readthedocs.io/en/stable/5_technical_guides/5_x_iman_conover.html
+
+        Examples
+        --------
+        Create a desired correction of 0.7 and a data set X with no correlation.
+        >>> correlation_matrix = np.array([[1, 0.7], [0.7, 1]])
+        >>> transform = ImanConover(correlation_matrix)
+        >>> X = np.array([[0, 0  ],
+        ...               [0, 0.5],
+        ...               [0,  1 ],
+        ...               [1, 0  ],
+        ...               [1, 0.5],
+        ...               [1, 1  ]])
+        >>> X_transformed = transform(X)
+        >>> X_transformed
+        array([[0. , 0. ],
+               [0. , 0. ],
+               [0. , 0.5],
+               [1. , 0.5],
+               [1. , 1. ],
+               [1. , 1. ]])
+
+        The original data X has no correlation at all, while the transformed
+        data has correlation that is closer to the desired correlation structure:
+
+        >>> sp.stats.pearsonr(*X.T).statistic
+        0.0
+        >>> sp.stats.pearsonr(*X_transformed.T).statistic
+        0.8164965809277261
+
+        Achieving the exact correlation structure might be impossible. For the
+        input matrix above, there is no permutation of the columns that yields
+        the exact desired correlation of 0.7. Iman-Conover is a heuristic that
+        tries to get as close as possible.
+
+        With many samples, we get good results if the data are normal:
+
+        >>> rng = np.random.default_rng(42)
+        >>> X = rng.normal(size=(1000, 2))
+        >>> X_transformed = transform(X)
+        >>> sp.stats.pearsonr(*X_transformed.T).statistic
+        0.697701261152449
+
+        But if the data are far from normal (here:lognormal), the results are
+        not as good. This is because correlation is induced in a normal space
+        before the result is mapped back to the original marginal distributions.
+
+        >>> rng = np.random.default_rng(42)
+        >>> X = rng.lognormal(size=(1000, 2))
+        >>> X_transformed = transform(X)
+        >>> sp.stats.pearsonr(*X_transformed.T).statistic
+        0.5925413169604046
+        """
+        if not isinstance(correlation_matrix, np.ndarray):
+            raise TypeError("Input argument `correlation_matrix` must be NumPy array.")
+        if not correlation_matrix.ndim == 2:
+            raise ValueError("Correlation matrix must be square.")
+        if not correlation_matrix.shape[0] == correlation_matrix.shape[1]:
+            raise ValueError("Correlation matrix must be square.")
+        # if not np.allclose(np.diag(correlation_matrix), 1.0):
+        #     raise ValueError("Correlation matrix must have 1.0 on diagonal.")
+        if not np.allclose(correlation_matrix.T, correlation_matrix):
+            raise ValueError("Correlation matrix must be symmetric.")
+        if not _is_positive_definite(correlation_matrix):
+            raise ValueError("Correlation matrix must be positive definite.")
+
+        self.C = correlation_matrix.copy()
+        self.P = np.linalg.cholesky(self.C)
+
+    def __call__(self, X):
+        """Transform an input matrix X.
+
+        The output will have the same marginal distributions, but with
+        induced correlation.
+
+        Parameters
+        ----------
+        X : ndarray
+            Input matrix of shape (N, K). This is the data set that we want to
+            induce correlation structure on. X must have at least K + 1
+            independent rows, because corr(X) cannot be singular.
+
+        Returns
+        -------
+        ndarray
+            Output matrix of shape (N, K). This data set will have a
+            correlation structure that is more similar to `correlation_matrix`.
+
+        """
+        if not isinstance(X, np.ndarray):
+            raise TypeError("Input argument `X` must be NumPy array.")
+        if not X.ndim == 2:
+            raise ValueError("Correlation matrix must be square.")
+
+        N, K = X.shape
+
+        if self.P.shape[0] != K:
+            msg = f"Shape of `X` ({X.shape}) does not match shape of "
+            msg += f"correlation matrix ({self.P.shape})"
+            raise ValueError(msg)
+
+        if N <= K:
+            msg = f"The matrix X must have rows > columns. Got shape: {X.shape}"
+            raise ValueError(msg)
+
+        # STEP ONE - Use van der Waerden scores to transform data to
+        # approximately multivariate normal (but with correlations).
+        # The new data has the same rank correlation as the original data.
+        ranks = sp.stats.rankdata(X, axis=0) / (N + 1)
+        normal_scores = sp.stats.norm.ppf(ranks)  # + np.random.randn(N, K) * epsilon
+
+        # STEP TWO - Remove correlations from the transformed data
+        empirical_correlation = np.corrcoef(normal_scores, rowvar=False)
+        if not _is_positive_definite(empirical_correlation):
+            msg = "Rank data correlation not positive definite."
+            msg += "There are perfect correlations in the ranked data."
+            msg += "Supply more data (rows in X) or sample differently."
+            raise ValueError(msg)
+
+        decorrelation_matrix = np.linalg.cholesky(empirical_correlation)
+
+        # We exploit the fact that Q is lower-triangular and avoid the inverse.
+        # X = N @ inv(Q)^T  =>  X @ Q^T = N  =>  (Q @ X^T)^T = N
+        decorrelated_scores = sp.linalg.solve_triangular(
+            decorrelation_matrix, normal_scores.T, lower=True
+        ).T
+
+        # STEP THREE - Induce correlations in transformed space
+        correlated_scores = decorrelated_scores @ self.P.T
+
+        # STEP FOUR - Map back to original space using ranks, ensuring
+        # that marginal distributions are preserved
+        result = np.empty_like(X)
+        for k in range(K):
+            # If row j is the k'th largest in `correlated_scores`, then
+            # we map the k'th largest entry in X to row j.
+            ranks = sp.stats.rankdata(correlated_scores[:, k]).astype(int) - 1
+            result[:, k] = np.sort(X[:, k])[ranks]
+
+        return result
+
+
+def decorrelate(X, remove_variance=True):
+    """Removes correlations or covariance from data X.
+
+    Examples
+    --------
+    >>> X = np.array([[1. , 1. ],
+    ...               [2. , 1.1],
+    ...               [2.1, 3. ]])
+    >>> X_decorr = decorrelate(X)
+    >>> np.cov(X_decorr, rowvar=False).round(6)
+    array([[1., 0.],
+           [0., 1.]])
+    >>> np.allclose(np.mean(X, axis=0), np.mean(X_decorr, axis=0))
+    True
+
+    >>> X_decorr = decorrelate(X, remove_variance=False)
+    >>> np.cov(X_decorr, rowvar=False).round(6)
+    array([[0.246667, 0.      ],
+           [0.      , 0.846667]])
+    >>> np.allclose(np.mean(X, axis=0), np.mean(X_decorr, axis=0))
+    True
+    """
+    mean = np.mean(X, axis=0)
+    var = np.var(X, axis=0)
+    cov = np.cov(X, rowvar=False)
+
+    L = np.linalg.cholesky(cov)  # L @ L.T = cov
+    if not remove_variance:
+        L = L / np.sqrt(var)
+
+    # Computes X = (X - mean) @ inv(L).T
+    X = sp.linalg.solve_triangular(L, (X - mean).T, lower=True).T
+
+    return mean + X
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()

--- a/tests/fmudesign/test_iman_conover.py
+++ b/tests/fmudesign/test_iman_conover.py
@@ -1,13 +1,14 @@
 import numpy as np
 import pytest
+import scipy as sp
 from scipy.stats import spearmanr
 
-from semeio.fmudesign import iman_conover
+from semeio.fmudesign.iman_conover import ImanConover, decorrelate
 
 
 @pytest.fixture
 def rng():
-    return np.random.RandomState()
+    return np.random.default_rng(42)
 
 
 @pytest.fixture
@@ -20,7 +21,7 @@ def sample_data(rng):
     X[:, 2] = rng.uniform(0, 1, N)
 
     # Ensure positive definite correlation matrix by constructing from random matrix
-    A = rng.randn(K, K)
+    A = rng.normal(size=(K, K))
     C = A @ A.T  # This creates a positive definite matrix
     # Convert to correlation matrix
     d = np.sqrt(np.diag(C))
@@ -32,34 +33,22 @@ def sample_data(rng):
 def test_preserves_marginal_distributions(rng, sample_data):
     X, C = sample_data
 
-    # Test basic method
-    X_basic = iman_conover(X, C, variance_reduction=False)
+    X_transformed = ImanConover(C)(X)
     for k in range(X.shape[1]):
-        assert np.allclose(np.sort(X[:, k]), np.sort(X_basic[:, k]))
-
-    # Test variance reduction method
-    X_var_red = iman_conover(X, C, variance_reduction=True)
-    for k in range(X.shape[1]):
-        assert np.allclose(np.sort(X[:, k]), np.sort(X_var_red[:, k]))
+        assert np.allclose(np.sort(X[:, k]), np.sort(X_transformed[:, k]))
 
 
 def test_achieves_target_correlations(sample_data):
     X, C = sample_data
 
-    # Test basic method
-    X_basic = iman_conover(X, C, variance_reduction=False)
-    rank_corr_basic = spearmanr(X_basic)[0]
-    assert np.allclose(rank_corr_basic, C, atol=0.1)
-
-    # Test variance reduction method
-    X_var_red = iman_conover(X, C, variance_reduction=True)
-    rank_corr_var_red = spearmanr(X_var_red)[0]
-    assert np.allclose(rank_corr_var_red, C, atol=0.05)
+    X_transformed = ImanConover(C)(X)
+    rank_corr = spearmanr(X_transformed)[0]
+    assert np.allclose(rank_corr, C, atol=0.05)
 
 
 def test_invalid_correlation_matrix(rng):
     N, K = 100, 3
-    X = rng.randn(N, K)
+    X = rng.normal(size=(N, K))
     C_invalid = np.array(
         [
             [1.0, 0.7, -0.3],
@@ -69,12 +58,12 @@ def test_invalid_correlation_matrix(rng):
     )
 
     with pytest.raises((ValueError, np.linalg.LinAlgError)):
-        iman_conover(X, C_invalid)
+        ImanConover(C_invalid)(X)
 
 
 def test_extreme_correlations(rng):
     N, K = 1000, 3
-    X = rng.randn(N, K)
+    X = rng.normal(size=(N, K))
 
     # Create extreme but valid correlation matrix
     # Using the fact that a correlation matrix with ones on diagonal
@@ -88,7 +77,7 @@ def test_extreme_correlations(rng):
     eigenvals = np.linalg.eigvals(C_extreme)
     assert np.all(eigenvals > 0), "Test correlation matrix is not positive definite"
 
-    X_extreme = iman_conover(X, C_extreme)
+    X_extreme = ImanConover(C_extreme)(X)
     rank_corr_extreme = spearmanr(X_extreme)[0]
     assert np.allclose(rank_corr_extreme, C_extreme, atol=0.05)
 
@@ -96,19 +85,19 @@ def test_extreme_correlations(rng):
 def test_correlation_matrix_validation(rng):
     N = 100
     K = 3
-    X = rng.randn(N, K)
+    X = rng.normal(size=(N, K))
 
     # Create non-positive definite matrix
     C_invalid = np.array([[1.0, 2.0, 0.3], [2.0, 1.0, 0.2], [0.3, 0.2, 1.0]])
 
-    with pytest.raises(np.linalg.LinAlgError):
-        iman_conover(X, C_invalid)
+    with pytest.raises((ValueError, np.linalg.LinAlgError)):
+        ImanConover(C_invalid)(X)
 
 
 def test_input_validation(rng):
     N = 100
     K = 3
-    X = rng.randn(N, K)
+    X = rng.normal(size=(N, K))
     C = np.array(
         [
             [1.0, 0.5],  # Wrong size
@@ -117,7 +106,7 @@ def test_input_validation(rng):
     )
 
     with pytest.raises(ValueError):
-        iman_conover(X, C)
+        ImanConover(C)(X)
 
 
 def test_orthogonality_precision(rng):
@@ -135,8 +124,8 @@ def test_orthogonality_precision(rng):
         ]
     )
 
-    X = rng.randn(N, K)
-    X_transformed = iman_conover(X, C_target)
+    X = rng.normal(size=(N, K))
+    X_transformed = ImanConover(C_target)(X)
     rank_corr = spearmanr(X_transformed)[0]
 
     # Get the elements that should be zero
@@ -151,3 +140,75 @@ def test_orthogonality_precision(rng):
     assert np.all(
         np.abs(achieved_zeros) < 0.12
     ), "Zero correlations not maintained with sufficient precision"
+
+
+class TestImanConover:
+    @pytest.mark.parametrize("seed", range(100))
+    def test_marginals_and_correlation_distance(self, seed):
+        rng = np.random.default_rng(seed)
+
+        n_variables = rng.integers(2, 100)
+        n_observations = n_variables * 10
+
+        # Create a random correlation matrix and a random data matrix
+        A = rng.normal(size=(n_variables * 2, n_variables))
+        desired_corr = 0.9 * np.corrcoef(A, rowvar=False) + 0.1 * np.eye(n_variables)
+        X = rng.normal(size=(n_observations, n_variables))
+
+        # Tranform the data
+        transform = ImanConover(desired_corr)
+        X_transformed = transform(X)
+
+        # Check that all columns (variables) have equal marginals.
+        # In other words, Iman-Conover can permute each column individually,
+        # but they should have identical entries before and after.
+        for j in range(X.shape[1]):
+            assert np.allclose(np.sort(X[:, j]), np.sort(X_transformed[:, j]))
+
+        # After the Iman-Conover transform, the distance between the desired
+        # correlation matrix should be smaller than it was before.
+        X_corr = np.corrcoef(X, rowvar=False)
+        distance_before = sp.linalg.norm(X_corr - desired_corr, ord="fro")
+
+        X_trans_corr = np.corrcoef(X_transformed, rowvar=False)
+        distance_after = sp.linalg.norm(X_trans_corr - desired_corr, ord="fro")
+
+        assert distance_after <= distance_before
+
+    def test_identity_correlation_matrix(self):
+        rng = np.random.default_rng(42)
+
+        n_observations = 5
+        n_variables = 3
+        rng = np.random.default_rng(42)
+
+        # Create a random correlation matrix and a random data matrix
+        desired_corr = np.identity(n_variables)
+        transform = ImanConover(desired_corr)
+
+        # Create data and decorrelate it completely
+        X = rng.normal(size=(n_observations, n_variables))
+        X = decorrelate(X, remove_variance=True)
+        assert np.allclose(np.corrcoef(X, rowvar=False), np.eye(n_variables))
+
+        # Transform it to identity correlation, which it already has
+        transform = ImanConover(desired_corr)
+        X_transformed = transform(X)
+
+        assert np.allclose(X, X_transformed)
+
+    def test_dataset_with_unity_correlation_in_ranks(self):
+        # This dataset is interesting because while the correlation
+        # between the variables is ~0.6, when the data is ranked the
+        # correlation becomes 1. Rank(row) = [1, 2, 3] for both rows.
+        X = np.array([[1.0, 1], [2.0, 1.1], [2.1, 3]])
+
+        desired_corr = np.identity(2)
+
+        transform = ImanConover(desired_corr)
+        with pytest.raises(ValueError):
+            transform(X)
+
+
+if __name__ == "__main__":
+    pytest.main(args=[__file__, "--doctest-modules", "-v", "-l"])


### PR DESCRIPTION
Updates the Iman-Conover transformation code. Non-functional changes: notation and using a class instead of a function.

Functional changes:
- `generate_van_der_waerden_scores` removed, replaced with vectorized version
- compute `S = P @ np.linalg.inv(Q)  # S = PQ^(-1)` without forming the inverse explicitly
- remove option `variance_reduction = False` (not in use, and likely will not be used)

I had to comment out a check for all ones on the diagonal user-supplied correlation matrix. Tests failed. This check will be added back in in the future, when we fix the `nearest correlation matrix` routine.