### PR TITLE
Run doctests in fmudesign as part of GH actions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -38,3 +38,6 @@ jobs:
 
       - name: "Run tests"
         run: pytest tests -n logical --durations 5 --ert-integration
+
+      - name: "Run doctests on fmudesign"
+        run: pytest ./src/semeio/fmudesign/ --doctest-modules -v

--- a/src/semeio/fmudesign/_designsummary.py
+++ b/src/semeio/fmudesign/_designsummary.py
@@ -32,11 +32,11 @@ def summarize_design(filename, sheetname="DesignSheet01"):
         'senstype', 'casename1', 'startreal1', 'endreal1',
         'casename2', 'startreal2', 'endreal2']
 
-    Example::
-        >>> from semeio.fmudesign import summarize_design
-        >>> designname = 'design_filename.xlsx'
-        >>> designsheet = 'DesignSheet01'
-        >>> designtable = summarize_design(designname, designsheet)
+    Example:
+        >> from semeio.fmudesign import summarize_design
+        >> designname = 'design_filename.xlsx'
+        >> designsheet = 'DesignSheet01'
+        >> designtable = summarize_design(designname, designsheet)
 
     """
 

--- a/src/semeio/fmudesign/_tornado_onebyone.py
+++ b/src/semeio/fmudesign/_tornado_onebyone.py
@@ -106,19 +106,19 @@ def calc_tornadoinput(
             * (int): Average response value for realizations in
                      reference sensitivity.
 
-    Example::
-        >>> import pandas as pd
-        >>> from semeio.fmudesign import calc_tornadoplot
-        >>> designtable = pd.read_csv('designsummary.csv')
-        >>> results = pd.read_csv('resultfile.csv')
-        >>> response = 'STOIIP_OIL'
-        >>> selectors = ['ZONE', 'REGION']
-        >>> selection = [['Nansen','Larsson'], ['SegmentA']]
-        >>> reference = 'rms_seed'
-        >>> scale = 'percentage'
-        >>> cutbyref = True
-        >>> sortsens = False
-        >>> (tornadotable, ref_value) = calc_tornadoinput(
+    Example:
+        >> import pandas as pd
+        >> from semeio.fmudesign import calc_tornadoplot
+        >> designtable = pd.read_csv('designsummary.csv')
+        >> results = pd.read_csv('resultfile.csv')
+        >> response = 'STOIIP_OIL'
+        >> selectors = ['ZONE', 'REGION']
+        >> selection = [['Nansen','Larsson'], ['SegmentA']]
+        >> reference = 'rms_seed'
+        >> scale = 'percentage'
+        >> cutbyref = True
+        >> sortsens = False
+        >> (tornadotable, ref_value) = calc_tornadoinput(
             designtable, results, response, selectors,
             selection, reference, scale, cutbyref, sortsens)
 

--- a/src/semeio/fmudesign/iman_conover.py
+++ b/src/semeio/fmudesign/iman_conover.py
@@ -18,12 +18,12 @@ Map to distributions
 Induce correlations
 
 >>> sp.stats.pearsonr(*X.T).statistic
-0.06589800321227991
+0.065898...
 >>> correlation_matrix = np.array([[1, 0.3], [0.3, 1]])
 >>> transform = ImanConover(correlation_matrix)
 >>> X_transformed = transform(X)
 >>> sp.stats.pearsonr(*X_transformed.T).statistic
-0.27965286549530805
+0.279652...
 """
 
 import numpy as np
@@ -89,7 +89,7 @@ class ImanConover:
         >>> sp.stats.pearsonr(*X.T).statistic
         0.0
         >>> sp.stats.pearsonr(*X_transformed.T).statistic
-        0.8164965809277261
+        0.816496...
 
         Achieving the exact correlation structure might be impossible. For the
         input matrix above, there is no permutation of the columns that yields
@@ -102,7 +102,7 @@ class ImanConover:
         >>> X = rng.normal(size=(1000, 2))
         >>> X_transformed = transform(X)
         >>> sp.stats.pearsonr(*X_transformed.T).statistic
-        0.697701261152449
+        0.697701...
 
         But if the data are far from normal (here:lognormal), the results are
         not as good. This is because correlation is induced in a normal space
@@ -112,7 +112,7 @@ class ImanConover:
         >>> X = rng.lognormal(size=(1000, 2))
         >>> X_transformed = transform(X)
         >>> sp.stats.pearsonr(*X_transformed.T).statistic
-        0.5925413169604046
+        0.592541...
         """
         if not isinstance(correlation_matrix, np.ndarray):
             raise TypeError("Input argument `correlation_matrix` must be NumPy array.")


### PR DESCRIPTION
In `fmudesign`, we added some doctests in previous PRs. They were not run, so I added a line in GH actions to run them. Some other examples did not actually run - here I simply replaced then `>>>` with `>>` syntax.