### PR TITLE
Converge on using ECLBASE instead of ECL_BASE

### DIFF
--- a/src/semeio/forward_models/__init__.py
+++ b/src/semeio/forward_models/__init__.py
@@ -92,7 +92,7 @@ class GenDataRFT(ForwardModelStepPlugin):
             command=[
                 "gendata_rft",
                 "-e",
-                "<ECL_BASE>",
+                "<ECLBASE>",
                 "-t",
                 "<PATH_TO_TRAJECTORY_FILES>",
                 "-w",

--- a/tests/forward_models/rft/conftest.py
+++ b/tests/forward_models/rft/conftest.py
@@ -4,10 +4,10 @@ import shutil
 
 import pytest
 
-ECL_BASE_NORNE = os.path.join(
+ECLBASE_NORNE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "data/norne/NORNE_ATW2013"
 )
-ECL_BASE_REEK = os.path.join(
+ECLBASE_REEK = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "data/reek/2_R001_REEK-0"
 )
 EXPECTED_RESULTS_PATH_NORNE = os.path.join(
@@ -25,11 +25,11 @@ MOCK_DATA_CONTENT_NORNE = {
 
 
 def get_ecl_base_norne():
-    return copy.copy(ECL_BASE_NORNE)
+    return copy.copy(ECLBASE_NORNE)
 
 
 def get_ecl_base_reek():
-    return copy.copy(ECL_BASE_REEK)
+    return copy.copy(ECLBASE_REEK)
 
 
 def get_expected_results_path_norne():

--- a/tests/forward_models/rft/test_gendata_rft.py
+++ b/tests/forward_models/rft/test_gendata_rft.py
@@ -12,8 +12,8 @@ import pytest
 from semeio.forward_models.scripts.gendata_rft import main_entry_point
 from tests.forward_models.rft import conftest
 
-ECL_BASE_NORNE = conftest.get_ecl_base_norne()
-ECL_BASE_REEK = conftest.get_ecl_base_reek()
+ECLBASE_NORNE = conftest.get_ecl_base_norne()
+ECLBASE_REEK = conftest.get_ecl_base_reek()
 MOCK_DATA_CONTENT_NORNE = conftest.get_mock_data_content_norne()
 EXPECTED_RESULTS_PATH_NORNE = conftest.get_expected_results_path_norne()
 
@@ -24,7 +24,7 @@ def test_gendata_rft_csv(tmpdir, monkeypatch):
     arguments = [
         "script_name",
         "-e",
-        ECL_BASE_NORNE,
+        ECLBASE_NORNE,
         "-w",
         "well_and_time.txt",
         "-t",
@@ -76,7 +76,7 @@ def test_gendata_rft_csv_reek(tmpdir, monkeypatch):
     arguments = [
         "script_name",
         "-e",
-        ECL_BASE_REEK,
+        ECLBASE_REEK,
         "-w",
         "well_and_time.txt",
         "-t",
@@ -106,7 +106,7 @@ def test_gendata_rft_directory(tmpdir, monkeypatch):
     arguments = [
         "script_name",
         "-e",
-        ECL_BASE_NORNE,
+        ECLBASE_NORNE,
         "-w",
         "well_and_time.txt",
         "-t",
@@ -131,7 +131,7 @@ def test_gendata_rft_entry_point_wrong_well_file(tmpdir, monkeypatch):
     arguments = [
         "script_name",
         "-e",
-        ECL_BASE_NORNE,
+        ECLBASE_NORNE,
         "-w",
         "well_and_time.txt",
         "-t",
@@ -151,7 +151,7 @@ def test_gendata_rft_entry_point(tmpdir, monkeypatch):
     arguments = [
         "script_name",
         "-e",
-        ECL_BASE_NORNE,
+        ECLBASE_NORNE,
         "-w",
         "well_and_time.txt",
         "-t",
@@ -194,7 +194,7 @@ def test_multiple_report_steps(tmpdir, monkeypatch):
     arguments = [
         "script_name",
         "-e",
-        ECL_BASE_REEK,
+        ECLBASE_REEK,
         "-w",
         "well_and_time.txt",
         "-t",
@@ -231,7 +231,7 @@ def test_gendata_inactive_info_point_not_in_grid(tmpdir, monkeypatch):
     arguments = [
         "script_name",
         "-e",
-        ECL_BASE_NORNE,
+        ECLBASE_NORNE,
         "-w",
         "well_and_time.txt",
         "-t",
@@ -268,7 +268,7 @@ def test_gendata_inactive_info_zone_mismatch(tmpdir, monkeypatch):
     arguments = [
         "script_name",
         "-e",
-        ECL_BASE_NORNE,
+        ECLBASE_NORNE,
         "-w",
         "well_and_time.txt",
         "-t",
@@ -303,7 +303,7 @@ def test_gendata_inactive_info_not_in_rft(tmpdir, monkeypatch):
     arguments = [
         "script_name",
         "-e",
-        ECL_BASE_NORNE,
+        ECLBASE_NORNE,
         "-w",
         "well_and_time.txt",
         "-t",
@@ -330,7 +330,7 @@ def test_gendata_inactive_info_zone_missing_value(tmpdir, monkeypatch):
     arguments = [
         "script_name",
         "-e",
-        ECL_BASE_NORNE,
+        ECLBASE_NORNE,
         "-w",
         "well_and_time.txt",
         "-t",
@@ -366,7 +366,7 @@ def test_partial_rft_file(tmpdir, monkeypatch, caplog):
     arguments = [
         "script_name",
         "-e",
-        ECL_BASE_NORNE,
+        ECLBASE_NORNE,
         "-w",
         "well_and_time.txt",
         "-t",
@@ -396,7 +396,7 @@ def test_one_wrong_date(tmpdir, monkeypatch, caplog):
     arguments = [
         "script_name",
         "-e",
-        ECL_BASE_NORNE,
+        ECLBASE_NORNE,
         "-w",
         "well_wrongtime.txt",
         "-t",
@@ -427,7 +427,7 @@ def test_empty_well_and_time(tmpdir, monkeypatch, caplog):
     arguments = [
         "script_name",
         "-e",
-        ECL_BASE_NORNE,
+        ECLBASE_NORNE,
         "-w",
         "empty.txt",
         "-t",
@@ -465,7 +465,7 @@ def test_ert_setup_one_well_one_rft_point(tmpdir):
     for real_id in [0, 1]:
         Path(f"realization-{real_id}/iter-0").mkdir(parents=True)
         Path(f"realization-{real_id}/iter-1").mkdir(parents=True)
-        for filename in Path(ECL_BASE_REEK).parent.glob("2_R001_REEK-0.*"):
+        for filename in Path(ECLBASE_REEK).parent.glob("2_R001_REEK-0.*"):
             shutil.copy(
                 filename,
                 Path(f"realization-{real_id}/iter-0")
@@ -578,7 +578,7 @@ def test_ert_setup_one_well_two_points_different_time_and_depth(tmpdir):
     for real_id in [0, 1]:
         Path(f"realization-{real_id}/iter-0").mkdir(parents=True)
         Path(f"realization-{real_id}/iter-1").mkdir(parents=True)
-        for filename in Path(ECL_BASE_REEK).parent.glob("2_R001_REEK-0.*"):
+        for filename in Path(ECLBASE_REEK).parent.glob("2_R001_REEK-0.*"):
             shutil.copy(
                 filename,
                 Path(f"realization-{real_id}/iter-0")

--- a/tests/forward_models/rft/test_trajectory_rftfile.py
+++ b/tests/forward_models/rft/test_trajectory_rftfile.py
@@ -10,8 +10,8 @@ from resdata.rft import ResdataRFTFile
 from semeio.forward_models.rft.trajectory import Trajectory, TrajectoryPoint
 from tests.forward_models.rft import conftest
 
-ECL_BASE_REEK = conftest.get_ecl_base_reek()
-ECL_BASE_NORNE = conftest.get_ecl_base_norne()
+ECLBASE_REEK = conftest.get_ecl_base_reek()
+ECLBASE_NORNE = conftest.get_ecl_base_norne()
 
 
 @pytest.mark.usefixtures("reek_data")
@@ -19,8 +19,8 @@ def test_update_simdata_from_rft_reek():
     """Test data extraction from the binary Eclipse files
     for a single well point using TrajectoryPoint.update_simdata_from_rft()"""
 
-    grid = Grid(ECL_BASE_REEK + ".EGRID")
-    rft = ResdataRFTFile(ECL_BASE_REEK + ".RFT")
+    grid = Grid(ECLBASE_REEK + ".EGRID")
+    rft = ResdataRFTFile(ECLBASE_REEK + ".RFT")
     rft_well_date = rft.get("OP_1", datetime.date(2000, 2, 1))
 
     # A trajectory point for an active cell in reek:
@@ -51,8 +51,8 @@ def test_update_simdata_from_rft_norne():
     does not contain saturations, and in libecl terms contains EclPLTCell
     as opposed to EclRFTCell as in Reek"""
 
-    grid = Grid(ECL_BASE_NORNE + ".EGRID")
-    rft = ResdataRFTFile(ECL_BASE_NORNE + ".RFT")
+    grid = Grid(ECLBASE_NORNE + ".EGRID")
+    rft = ResdataRFTFile(ECLBASE_NORNE + ".RFT")
     rft_well_date = rft.get("C-3H", datetime.date(1999, 5, 4))
 
     # A trajectory point for an active cell in Norne, picked
@@ -83,8 +83,8 @@ def test_update_simdata_from_rft_norne():
 
 
 def test_update_simdata_outside_grid():
-    grid = Grid(ECL_BASE_REEK + ".EGRID")
-    rft = ResdataRFTFile(ECL_BASE_REEK + ".RFT")
+    grid = Grid(ECLBASE_REEK + ".EGRID")
+    rft = ResdataRFTFile(ECLBASE_REEK + ".RFT")
     rft_well_date = rft.get("OP_1", datetime.date(2000, 2, 1))
 
     # A point outside the grid:
@@ -103,8 +103,8 @@ def test_update_simdata_outside_grid():
 
 
 def test_update_simdata_outside_well():
-    grid = Grid(ECL_BASE_REEK + ".EGRID")
-    rft = ResdataRFTFile(ECL_BASE_REEK + ".RFT")
+    grid = Grid(ECLBASE_REEK + ".EGRID")
+    rft = ResdataRFTFile(ECLBASE_REEK + ".RFT")
     rft_well_date = rft.get("OP_1", datetime.date(2000, 2, 1))
 
     # A point in the grid, but not related to the well

--- a/tests/test_ert_integration.py
+++ b/tests/test_ert_integration.py
@@ -50,7 +50,7 @@ def test_console_scripts_exit_code(script_runner, entry_point, options):
             "<template_file>=no_template",
             " no_template is not an existing file!",
         ),
-        ("GENDATA_RFT", "<ECL_BASE>=not_ecl", "The path not_ecl.RFT does not exist"),
+        ("GENDATA_RFT", "<ECLBASE>=not_ecl", "The path not_ecl.RFT does not exist"),
         ("PYSCAL", "<PARAMETER_FILE>=not_file", "not_file does not exist"),
     ],
 )


### PR DESCRIPTION
ECL_BASE is aliased to ECLBASE when Ert parses configs, but there is no good reason to rely on that.

Related to https://github.com/equinor/ert/issues/10215