### PR TITLE
Add type annotations

### DIFF
--- a/src/semeio/__init__.py
+++ b/src/semeio/__init__.py
@@ -25,7 +25,7 @@ std_err_handler.setLevel(logging.WARNING)
 logger.addHandler(std_err_handler)
 
 
-def valid_file(arg):
+def valid_file(arg: str) -> str:
     if os.path.isfile(arg):
         return arg
     raise argparse.ArgumentTypeError(f"{arg} is not an existing file!")

--- a/src/semeio/_docs_utils/_json_schema_2_rst.py
+++ b/src/semeio/_docs_utils/_json_schema_2_rst.py
@@ -1,8 +1,9 @@
 import textwrap
 from copy import deepcopy
+from typing import Any
 
 
-def _insert_ref(schema: dict, defs: dict) -> dict:
+def _insert_ref(schema: dict[str, Any], defs: dict[str, Any]) -> dict[str, Any]:
     schema_copy = schema.copy()
     for index, value in schema_copy.items():
         if isinstance(value, dict):
@@ -19,7 +20,7 @@ def _insert_ref(schema: dict, defs: dict) -> dict:
     return schema
 
 
-def _remove_key(schema: dict, del_key: str) -> None:
+def _remove_key(schema: dict[str, Any], del_key: str) -> None:
     schema_copy = schema.copy()
     for key, val in schema_copy.items():
         if key == del_key:
@@ -28,7 +29,7 @@ def _remove_key(schema: dict, del_key: str) -> None:
             _remove_key(schema[key], del_key)
 
 
-def _replace_key(schema: dict, old_key: str, new_key: str) -> None:
+def _replace_key(schema: dict[str, Any], old_key: str, new_key: str) -> None:
     schema_copy = schema.copy()
     for key, val in schema_copy.items():
         if key == old_key:
@@ -39,7 +40,7 @@ def _replace_key(schema: dict, old_key: str, new_key: str) -> None:
             _replace_key(schema[key], old_key, new_key)
 
 
-def _create_docs(schema: dict) -> str:
+def _create_docs(schema: dict[str, Any]) -> str:
     """While there are alternatives to implementing something new, most of these
     rely on a sphinx directive, which we can not easily use here. There are
     also libraries such as jsonschema2rst, but they only document their
@@ -66,14 +67,14 @@ def _create_docs(schema: dict) -> str:
 
 
 def _make_documentation(
-    schema: list | dict | str,
+    schema: list[str] | dict[str, Any] | str,
     required: list[str] | None = None,
     level: int = 0,
     preface: str = "",
     element_seperator: str = "\n\n",
 ) -> str:
     indent = level * 2 * " "
-    docs = []
+    docs: list[str] = []
     required = required if required is not None else []
     if isinstance(schema, dict):
         for key, val in schema.items():
@@ -103,7 +104,7 @@ def _make_documentation(
             else:
                 docs += [indent + f"**{key}**: {val}"]
     elif isinstance(schema, list):
-        list_docs = []
+        list_docs: list[str] = []
         for element in schema:
             list_docs += [
                 _make_documentation(

--- a/src/semeio/_exceptions/exceptions.py
+++ b/src/semeio/_exceptions/exceptions.py
@@ -1,10 +1,10 @@
 class ConfigurationError(Exception):
-    def __init__(self, message, errors):
+    def __init__(self, message: str, errors: Exception):
         super().__init__(message)
         self.errors = errors
         self.message = message
 
-    def __str__(self):
+    def __str__(self) -> str:
         msg = f"{self.message}"
         for error in self.errors:
             msg += f"\n{error}"

--- a/src/semeio/fmudesign/_designsummary.py
+++ b/src/semeio/fmudesign/_designsummary.py
@@ -9,7 +9,7 @@ def _get_sensitivity_type(senscase: str) -> str:
     return sensitivity_types.get(senscase.lower(), "scalar")
 
 
-def summarize_design(filename, sheetname="DesignSheet01"):
+def summarize_design(filename: str, sheetname: str = "DesignSheet01") -> pd.DataFrame:
     """
      Summarizes the design set up for one by one sensitivities
      specified in a design matrix on standard fmu format.

--- a/src/semeio/fmudesign/_excel2dict.py
+++ b/src/semeio/fmudesign/_excel2dict.py
@@ -4,6 +4,8 @@ read by semeio.fmudesign.DesignMatrix.generate
 """
 
 from collections import OrderedDict
+from collections.abc import Mapping
+from typing import Any
 
 import numpy as np
 import openpyxl
@@ -11,7 +13,9 @@ import pandas as pd
 import yaml
 
 
-def excel2dict_design(input_filename, sheetnames=None):
+def excel2dict_design(
+    input_filename: str, sheetnames: Mapping[str, Any] | None = None
+) -> OrderedDict[str, Any]:
     """Read excel file with input to design setup
     Currently only specification of
     onebyone design is implemented
@@ -53,7 +57,7 @@ def excel2dict_design(input_filename, sheetnames=None):
     return returndict
 
 
-def inputdict_to_yaml(inputdict, filename):
+def inputdict_to_yaml(inputdict: OrderedDict[str, Any], filename: str) -> None:
     """Write inputdict to yaml format
 
     Args:
@@ -64,12 +68,12 @@ def inputdict_to_yaml(inputdict, filename):
         yaml.dump(inputdict, stream)
 
 
-def _find_geninput_sheetname(input_filename):
+def _find_geninput_sheetname(input_filename: str) -> str:
     """Finding general input sheet, allowing for name
     variations."""
     xlsx = openpyxl.load_workbook(input_filename, read_only=True, keep_links=False)
     sheets = xlsx.sheetnames
-    general_input_sheet = []
+    general_input_sheet: list[str] = []
     for sheet in sheets:
         if sheet in [
             "general_input",
@@ -94,7 +98,7 @@ def _find_geninput_sheetname(input_filename):
     return general_input_sheet[0]
 
 
-def _find_onebyone_defaults_sheet(input_filename):
+def _find_onebyone_defaults_sheet(input_filename: str) -> str:
     """Finds correct sheet name for default values to use when parsing
     excel file.
 
@@ -104,7 +108,7 @@ def _find_onebyone_defaults_sheet(input_filename):
     xlsx = openpyxl.load_workbook(input_filename, read_only=True, keep_links=False)
     sheets = xlsx.sheetnames
 
-    default_values_sheet = []
+    default_values_sheet: list[str] = []
 
     for sheet in sheets:
         if sheet in [
@@ -129,7 +133,7 @@ def _find_onebyone_defaults_sheet(input_filename):
     return default_values_sheet[0]
 
 
-def _find_onebyone_input_sheet(input_filename):
+def _find_onebyone_input_sheet(input_filename: str) -> str:
     """Finds correct sheet name for input to use when parsing excel file.
 
     Returns:
@@ -138,7 +142,7 @@ def _find_onebyone_input_sheet(input_filename):
     xlsx = openpyxl.load_workbook(input_filename, read_only=True, keep_links=False)
     sheets = xlsx.sheetnames
 
-    design_input_sheet = []
+    design_input_sheet: list[str] = []
 
     for sheet in sheets:
         if sheet in [
@@ -162,11 +166,11 @@ def _find_onebyone_input_sheet(input_filename):
     return design_input_sheet[0]
 
 
-def _check_designinput(dsgn_input):
+def _check_designinput(dsgn_input: pd.DataFrame) -> None:
     """Checks for valid input in designinput sheet"""
 
     # Check for duplicate sensnames
-    sensitivity_names = []
+    sensitivity_names: list[str] = []
     for row in dsgn_input.itertuples():
         if _has_value(row.sensname):
             if row.sensname in sensitivity_names:
@@ -178,7 +182,7 @@ def _check_designinput(dsgn_input):
             sensitivity_names.append(row.sensname)
 
 
-def _check_for_mixed_sensitivities(sens_name, sens_group):
+def _check_for_mixed_sensitivities(sens_name: str, sens_group: pd.DataFrame) -> None:
     """Checks for valid input in designinput sheet. A sensitivity cannot contain
     two different sensitivity types"""
 
@@ -192,7 +196,10 @@ def _check_for_mixed_sensitivities(sens_name, sens_group):
         )
 
 
-def _excel2dict_onebyone(input_filename, sheetnames=None):
+def _excel2dict_onebyone(
+    input_filename: str,
+    sheetnames: Mapping[str, Any] | None = None,
+) -> OrderedDict[str, Any]:
     """Reads specification for onebyone design
 
     Args:
@@ -206,7 +213,7 @@ def _excel2dict_onebyone(input_filename, sheetnames=None):
     """
 
     seedname = "RMS_SEED"
-    inputdict = OrderedDict()
+    inputdict: OrderedDict[str, Any] = OrderedDict()
 
     if not sheetnames or "general_input" not in sheetnames:
         gen_input_sheet = _find_geninput_sheetname(input_filename)
@@ -313,7 +320,7 @@ def _excel2dict_onebyone(input_filename, sheetnames=None):
     for sensname, group in grouped:
         _check_for_mixed_sensitivities(sensname, group)
 
-        sensdict = OrderedDict()
+        sensdict: OrderedDict[str, Any] = OrderedDict()
 
         if group["type"].iloc[0] == "ref":
             sensdict["senstype"] = "ref"
@@ -360,7 +367,7 @@ def _excel2dict_onebyone(input_filename, sheetnames=None):
     return inputdict
 
 
-def _read_defaultvalues(filename, sheetname):
+def _read_defaultvalues(filename: str, sheetname: str) -> OrderedDict[str, Any]:
     """Reads defaultvalues, also used as values for
     reference/base case
 
@@ -371,7 +378,7 @@ def _read_defaultvalues(filename, sheetname):
     Returns:
         OrderedDict with defaultvalues (parameter, value)
     """
-    default_dict = OrderedDict()
+    default_dict: OrderedDict[str, Any] = OrderedDict()
     default_df = pd.read_excel(
         filename, sheetname, header=0, index_col=0, engine="openpyxl"
     )
@@ -398,7 +405,9 @@ def _read_defaultvalues(filename, sheetname):
     return default_dict
 
 
-def _read_dependencies(filename, sheetname, from_parameter):
+def _read_dependencies(
+    filename: str, sheetname: str, from_parameter: str
+) -> OrderedDict[str, Any]:
     """Reads parameters that are set from other parameters
 
     Args:
@@ -409,7 +418,7 @@ def _read_dependencies(filename, sheetname, from_parameter):
         OrderedDict with design parameter, dependent parameters
         and values
     """
-    depend_dict = OrderedDict()
+    depend_dict: OrderedDict[str, Any] = OrderedDict()
     depend_df = pd.read_excel(
         filename, sheetname, dtype=str, na_values="", engine="openpyxl"
     )
@@ -433,7 +442,7 @@ def _read_dependencies(filename, sheetname, from_parameter):
     return depend_dict
 
 
-def _read_background(inp_filename, bck_sheet):
+def _read_background(inp_filename: str, bck_sheet: str) -> OrderedDict[str, Any]:
     """Reads excel sheet with background parameters and distributions
 
     Args:
@@ -443,8 +452,8 @@ def _read_background(inp_filename, bck_sheet):
     Returns:
         OrderedDict with parameter names and distributions
     """
-    backdict = OrderedDict()
-    paramdict = OrderedDict()
+    backdict: OrderedDict[str, Any] = OrderedDict()
+    paramdict: OrderedDict[str, Any] = OrderedDict()
     bck_input = pd.read_excel(inp_filename, bck_sheet, engine="openpyxl")
     bck_input.dropna(axis=0, how="all", inplace=True)
     bck_input = bck_input.loc[
@@ -511,7 +520,7 @@ def _read_background(inp_filename, bck_sheet):
     backdict["parameters"] = paramdict
 
     if "decimals" in bck_input:
-        decimals = OrderedDict()
+        decimals: OrderedDict[str, Any] = OrderedDict()
         for row in bck_input.itertuples():
             if _has_value(row.decimals) and _is_int(row.decimals):
                 decimals[row.param_name] = int(row.decimals)
@@ -520,14 +529,14 @@ def _read_background(inp_filename, bck_sheet):
     return backdict
 
 
-def _read_scenario_sensitivity(sensgroup):
+def _read_scenario_sensitivity(sensgroup: pd.DataFrame) -> OrderedDict[str, Any]:
     """Reads parameters and values
     for scenario sensitivities
     """
-    sdict = OrderedDict()
+    sdict: OrderedDict[str, Any] = OrderedDict()
     sdict["cases"] = OrderedDict()
-    casedict1 = OrderedDict()
-    casedict2 = OrderedDict()
+    casedict1: OrderedDict[str, Any] = OrderedDict()
+    casedict2: OrderedDict[str, Any] = OrderedDict()
 
     if not _has_value(sensgroup["senscase1"].iloc[0]):
         raise ValueError(
@@ -581,12 +590,12 @@ def _read_scenario_sensitivity(sensgroup):
     return sdict
 
 
-def _read_constants(sensgroup):
+def _read_constants(sensgroup: pd.DataFrame) -> OrderedDict[str, Any]:
     """Reads constants to be used together with
     seed sensitivity"""
     if "dist_param1" not in sensgroup.columns.values:
         sensgroup["dist_param1"] = float("NaN")
-    paramdict = OrderedDict()
+    paramdict: OrderedDict[str, Any] = OrderedDict()
     for row in sensgroup.itertuples():
         if not _has_value(row.dist_param1):
             raise ValueError(
@@ -607,7 +616,7 @@ def _read_constants(sensgroup):
     return paramdict
 
 
-def _read_dist_sensitivity(sensgroup):
+def _read_dist_sensitivity(sensgroup: pd.DataFrame) -> OrderedDict[str, Any]:
     """Reads parameters and distributions
     for monte carlo sensitivities
     """
@@ -619,7 +628,7 @@ def _read_dist_sensitivity(sensgroup):
         sensgroup["dist_param3"] = float("NaN")
     if "dist_param4" not in sensgroup.columns.values:
         sensgroup["dist_param4"] = float("NaN")
-    paramdict = OrderedDict()
+    paramdict: OrderedDict[str, Any] = OrderedDict()
     for row in sensgroup.itertuples():
         if not _has_value(row.param_name):
             raise ValueError(
@@ -666,10 +675,12 @@ def _read_dist_sensitivity(sensgroup):
     return paramdict
 
 
-def _read_correlations(sensgroup, inputfile):
+def _read_correlations(
+    sensgroup: pd.DataFrame, inputfile: str
+) -> OrderedDict[str, Any] | None:
     if "corr_sheet" in sensgroup:
         if not sensgroup["corr_sheet"].dropna().empty:
-            correlations = OrderedDict()
+            correlations: OrderedDict[str, Any] | None = OrderedDict()
             correlations["inputfile"] = inputfile
             correlations["sheetnames"] = []
             for _index, row in sensgroup.iterrows():
@@ -686,7 +697,7 @@ def _read_correlations(sensgroup, inputfile):
     return correlations
 
 
-def _has_value(value):
+def _has_value(value: Any) -> bool:
     """Returns False only if the argument is np.nan"""
     try:
         return not np.isnan(value)
@@ -694,7 +705,7 @@ def _has_value(value):
         return True
 
 
-def _is_int(teststring):
+def _is_int(teststring: str) -> bool:
     """Test if a string can be parsed as a float"""
     try:
         if not np.isnan(int(teststring)):

--- a/src/semeio/fmudesign/_excel2dict.py
+++ b/src/semeio/fmudesign/_excel2dict.py
@@ -170,7 +170,7 @@ def _check_designinput(dsgn_input: pd.DataFrame) -> None:
     """Checks for valid input in designinput sheet"""
 
     # Check for duplicate sensnames
-    sensitivity_names: list[str] = []
+    sensitivity_names = []
     for row in dsgn_input.itertuples():
         if _has_value(row.sensname):
             if row.sensname in sensitivity_names:

--- a/src/semeio/fmudesign/_tornado_onebyone.py
+++ b/src/semeio/fmudesign/_tornado_onebyone.py
@@ -1,12 +1,14 @@
 """Module for calculating values for a tornadoplot"""
 
 from collections.abc import Sequence
+from typing import Any
 
 import pandas as pd
 from deprecation import deprecated
+from pandas.core.frame import DataFrame
 
 
-def real_mask(dfr: pd.DataFrame, start: int, end: int):
+def real_mask(dfr: pd.DataFrame, start: int, end: int) -> pd.Series[bool]:
     """Creates mask for which realisations to calc from"""
     return (start <= dfr.REAL) & (end >= dfr.REAL)
 
@@ -32,7 +34,7 @@ def check_selection(
         resultfile[selector].values.astype(str)
 
 
-def check_response(resultfile: pd.DataFrame, response: str):
+def check_response(resultfile: pd.DataFrame, response: str) -> None:
     """Checks whether responses in in resultfile"""
     if response not in resultfile.columns:
         raise ValueError("Did not find ", response, " as column in", "resultfile")
@@ -76,7 +78,7 @@ def calc_tornadoinput(
     scale: str = "percentage",
     cutbyref: bool = False,
     sortsens: bool = True,
-):
+) -> tuple[DataFrame, Any]:
     """
      Calculates input values for a tornadoplot for one response
      and one design set up

--- a/src/semeio/fmudesign/_tornado_onebyone.py
+++ b/src/semeio/fmudesign/_tornado_onebyone.py
@@ -5,10 +5,9 @@ from typing import Any
 
 import pandas as pd
 from deprecation import deprecated
-from pandas.core.frame import DataFrame
 
 
-def real_mask(dfr: pd.DataFrame, start: int, end: int) -> pd.Series[bool]:
+def real_mask(dfr: pd.DataFrame, start: int, end: int) -> "pd.Series[bool]":
     """Creates mask for which realisations to calc from"""
     return (start <= dfr.REAL) & (end >= dfr.REAL)
 
@@ -78,7 +77,7 @@ def calc_tornadoinput(
     scale: str = "percentage",
     cutbyref: bool = False,
     sortsens: bool = True,
-) -> tuple[DataFrame, Any]:
+) -> tuple[pd.DataFrame, Any]:
     """
      Calculates input values for a tornadoplot for one response
      and one design set up

--- a/src/semeio/fmudesign/_tornado_onebyone.py
+++ b/src/semeio/fmudesign/_tornado_onebyone.py
@@ -1,21 +1,25 @@
 """Module for calculating values for a tornadoplot"""
 
+from collections.abc import Sequence
+
 import pandas as pd
 from deprecation import deprecated
 
 
-def real_mask(dfr, start, end):
+def real_mask(dfr: pd.DataFrame, start: int, end: int):
     """Creates mask for which realisations to calc from"""
     return (start <= dfr.REAL) & (end >= dfr.REAL)
 
 
-def check_selector(resultfile, selector):
+def check_selector(resultfile: pd.DataFrame, selector: str) -> None:
     """Checks whether selector is in resultfile headers"""
     if selector not in resultfile.columns:
         raise ValueError("Did not find ", selector, " as column in", "resultfile")
 
 
-def check_selection(resultfile, selector, selection):
+def check_selection(
+    resultfile: pd.DataFrame, selector: str, selection: Sequence[str]
+) -> None:
     """Checks whether selection is in resultfile values
     in the column selector"""
     for sel in selection:
@@ -28,13 +32,13 @@ def check_selection(resultfile, selector, selection):
         resultfile[selector].values.astype(str)
 
 
-def check_response(resultfile, response):
+def check_response(resultfile: pd.DataFrame, response: str):
     """Checks whether responses in in resultfile"""
     if response not in resultfile.columns:
         raise ValueError("Did not find ", response, " as column in", "resultfile")
 
 
-def cut_by_ref(tornadotable, refname):
+def cut_by_ref(tornadotable: pd.DataFrame, refname: str) -> pd.DataFrame:
     """Removes sensitivities smaller than reference sensitivity from table"""
     maskref = tornadotable.sensname == refname
     reflow = tornadotable[maskref].low.abs()
@@ -49,7 +53,7 @@ def cut_by_ref(tornadotable, refname):
     ]
 
 
-def sort_by_max(tornadotable):
+def sort_by_max(tornadotable: pd.DataFrame) -> pd.DataFrame:
     """Sorts table based on max(abs('low', 'high'))"""
     tornadotable["max"] = (
         tornadotable[["low", "high"]]
@@ -63,15 +67,15 @@ def sort_by_max(tornadotable):
 
 @deprecated(details="Use TornadoPlotterFMU from webviz instead")
 def calc_tornadoinput(
-    designsummary,
-    resultfile,
-    response,
-    selectors,
-    selection,
-    reference="rms_seed",
-    scale="percentage",
-    cutbyref=False,
-    sortsens=True,
+    designsummary: pd.DataFrame,
+    resultfile: pd.DataFrame,
+    response: str,
+    selectors: Sequence[str],
+    selection: Sequence[Sequence[str]],
+    reference: str = "rms_seed",
+    scale: str = "percentage",
+    cutbyref: bool = False,
+    sortsens: bool = True,
 ):
     """
      Calculates input values for a tornadoplot for one response

--- a/src/semeio/fmudesign/create_design.py
+++ b/src/semeio/fmudesign/create_design.py
@@ -33,7 +33,7 @@ from semeio.fmudesign import design_distributions as design_dist
 from semeio.fmudesign.iman_conover import ImanConover
 
 
-def is_consistent_correlation_matrix(matrix: npt.NDArray[np.float64]) -> bool:
+def is_consistent_correlation_matrix(matrix: npt.NDArray[Any]) -> bool:
     """
     Check if a matrix is a consistent correlation matrix.
 
@@ -65,9 +65,9 @@ def is_consistent_correlation_matrix(matrix: npt.NDArray[np.float64]) -> bool:
 
 
 def nearest_correlation_matrix(
-    matrix: npt.NDArray[np.float64],
+    matrix: npt.NDArray[Any],
     *,
-    weights: npt.NDArray[np.float64] | None = None,
+    weights: npt.NDArray[Any] | None = None,
     eps: float = 1e-6,
     verbose: bool = False,
 ) -> npt.NDArray[np.float64]:
@@ -844,7 +844,7 @@ class MonteCarloSensitivity:
         dist_params: Sequence[str],
         numreals: int,
         rng: np.random.RandomState,
-    ) -> npt.NDArray[np.float64] | list[str] | str:
+    ) -> npt.NDArray[Any] | list[str] | str:
         try:
             return design_dist.draw_values(
                 dist_name.lower(), dist_params, numreals, rng

--- a/src/semeio/fmudesign/design_distributions.py
+++ b/src/semeio/fmudesign/design_distributions.py
@@ -5,6 +5,7 @@ distributions. For use in generation of design matrices
 import re
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -151,7 +152,7 @@ def _check_dist_params_logunif(dist_params: Sequence[str]) -> tuple[bool, str]:
 
 def generate_stratified_samples(
     numreals: int, rng: np.random.RandomState
-) -> npt.NDArray[np.float64]:
+) -> npt.NDArray[Any]:
     """Generate stratified samples in [0,1] by dividing the interval
     into equal-probability strata.
 

--- a/src/semeio/fmudesign/design_distributions.py
+++ b/src/semeio/fmudesign/design_distributions.py
@@ -3,15 +3,17 @@ distributions. For use in generation of design matrices
 """
 
 import re
+from collections.abc import Sequence
 from pathlib import Path
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 import scipy.stats
 from scipy.stats import qmc
 
 
-def _check_dist_params_normal(dist_params):
+def _check_dist_params_normal(dist_params: Sequence[str]) -> tuple[bool, str]:
     if len(dist_params) not in [2, 4]:
         status = False
         msg = (
@@ -39,7 +41,7 @@ def _check_dist_params_normal(dist_params):
     return status, msg
 
 
-def _check_dist_params_lognormal(dist_params):
+def _check_dist_params_lognormal(dist_params: Sequence[str]) -> tuple[bool, str]:
     if len(dist_params) != 2:
         status = False
         msg = (
@@ -59,7 +61,7 @@ def _check_dist_params_lognormal(dist_params):
     return status, msg
 
 
-def _check_dist_params_uniform(dist_params):
+def _check_dist_params_uniform(dist_params: Sequence[str]) -> tuple[bool, str]:
     if len(dist_params) != 2:
         status = False
         msg = (
@@ -79,7 +81,7 @@ def _check_dist_params_uniform(dist_params):
     return status, msg
 
 
-def _check_dist_params_triang(dist_params):
+def _check_dist_params_triang(dist_params: Sequence[str]) -> tuple[bool, str]:
     if len(dist_params) != 3:
         status = False
         msg = (
@@ -102,7 +104,7 @@ def _check_dist_params_triang(dist_params):
     return status, msg
 
 
-def _check_dist_params_pert(dist_params):
+def _check_dist_params_pert(dist_params: Sequence[str]) -> tuple[bool, str]:
     if len(dist_params) not in [3, 4]:
         status = False
         msg = (
@@ -125,7 +127,7 @@ def _check_dist_params_pert(dist_params):
     return status, msg
 
 
-def _check_dist_params_logunif(dist_params):
+def _check_dist_params_logunif(dist_params: Sequence[str]) -> tuple[bool, str]:
     if len(dist_params) != 2:
         status = False
         msg = (
@@ -147,7 +149,9 @@ def _check_dist_params_logunif(dist_params):
     return status, msg
 
 
-def generate_stratified_samples(numreals, rng):
+def generate_stratified_samples(
+    numreals: int, rng: np.random.RandomState
+) -> npt.NDArray[np.float64]:
     """Generate stratified samples in [0,1] by dividing the interval
     into equal-probability strata.
 
@@ -173,7 +177,12 @@ def generate_stratified_samples(numreals, rng):
     return samples.flatten()
 
 
-def draw_values_normal(dist_parameters, numreals, rng, normalscoresamples=None):
+def draw_values_normal(
+    dist_parameters: Sequence[str],
+    numreals: int,
+    rng: np.random.RandomState,
+    normalscoresamples: npt.NDArray[np.float64] | None = None,
+) -> npt.NDArray[np.float64]:
     status, msg = _check_dist_params_normal(dist_parameters)
 
     if not status:
@@ -212,7 +221,12 @@ def draw_values_normal(dist_parameters, numreals, rng, normalscoresamples=None):
     return values
 
 
-def draw_values_lognormal(dist_parameters, numreals, rng, normalscoresamples=None):
+def draw_values_lognormal(
+    dist_parameters: Sequence[str],
+    numreals: int,
+    rng: np.random.RandomState,
+    normalscoresamples: npt.NDArray[np.float64] | None = None,
+) -> npt.NDArray[np.float64]:
     """Draws values from lognormal distribution.
     Args:
         dist_parameters(list): [mu, sigma] for the logarithm of the variable
@@ -244,7 +258,12 @@ def draw_values_lognormal(dist_parameters, numreals, rng, normalscoresamples=Non
     return values
 
 
-def draw_values_uniform(dist_parameters, numreals, rng, normalscoresamples=None):
+def draw_values_uniform(
+    dist_parameters: Sequence[str],
+    numreals: int,
+    rng: np.random.RandomState,
+    normalscoresamples: npt.NDArray[np.float64] | None = None,
+) -> npt.NDArray[np.float64]:
     """Draws values from uniform distribution.
     Args:
         dist_parameters(list): [minimum, maximum]
@@ -277,7 +296,12 @@ def draw_values_uniform(dist_parameters, numreals, rng, normalscoresamples=None)
     return scipy.stats.uniform.ppf(uniform_samples, loc=low, scale=uscale)
 
 
-def draw_values_triangular(dist_parameters, numreals, rng, normalscoresamples=None):
+def draw_values_triangular(
+    dist_parameters: Sequence[str],
+    numreals: int,
+    rng: np.random.RandomState,
+    normalscoresamples: npt.NDArray[np.float64] | None = None,
+) -> npt.NDArray[np.float64]:
     """Draws values from triangular distribution.
     Args:
         dist_parameters(list): [min, mode, max]
@@ -326,7 +350,12 @@ def draw_values_triangular(dist_parameters, numreals, rng, normalscoresamples=No
     return values
 
 
-def draw_values_pert(dist_parameters, numreals, rng, normalscoresamples=None):
+def draw_values_pert(
+    dist_parameters: Sequence[str],
+    numreals: int,
+    rng: np.random.RandomState,
+    normalscoresamples: npt.NDArray[np.float64] | None = None,
+) -> npt.NDArray[np.float64]:
     """Draws values from pert distribution.
     Args:
         dist_parameters(list): [min, mode, max, scale]
@@ -382,7 +411,12 @@ def draw_values_pert(dist_parameters, numreals, rng, normalscoresamples=None):
     return values * (high - low) + low
 
 
-def draw_values_loguniform(dist_parameters, numreals, rng, normalscoresamples=None):
+def draw_values_loguniform(
+    dist_parameters: Sequence[str],
+    numreals: int,
+    rng: np.random.RandomState,
+    normalscoresamples: npt.NDArray[np.float64] | None = None,
+) -> npt.NDArray[np.float64]:
     """Draws values from loguniform distribution.
     Args:
         dist_parameters(list): [minimum, maximum]
@@ -410,7 +444,13 @@ def draw_values_loguniform(dist_parameters, numreals, rng, normalscoresamples=No
     return values
 
 
-def draw_values(distname, dist_parameters, numreals, rng, normalscoresamples=None):
+def draw_values(
+    distname: str,
+    dist_parameters: Sequence[str],
+    numreals: int,
+    rng: np.random.RandomState,
+    normalscoresamples: npt.NDArray[np.float64] | None = None,
+) -> npt.NDArray[np.float64] | list[str] | str:
     """
     Prepare scipy distributions with parameters
     Args:
@@ -463,7 +503,12 @@ def draw_values(distname, dist_parameters, numreals, rng, normalscoresamples=Non
     return values
 
 
-def sample_discrete(dist_params, numreals, rng, normalscoresamples=None):
+def sample_discrete(
+    dist_params: Sequence[str],
+    numreals: int,
+    rng: np.random.RandomState,
+    normalscoresamples: npt.NDArray[np.float64] | None = None,
+) -> tuple[bool, npt.NDArray[np.float64] | str]:
     status = True
     outcomes = re.split(",", dist_params[0])
     outcomes = [item.strip() for item in outcomes]
@@ -506,7 +551,7 @@ def sample_discrete(dist_params, numreals, rng, normalscoresamples=None):
     return status, values
 
 
-def is_number(teststring):
+def is_number(teststring: str) -> bool:
     """Test if a string can be parsed as a float"""
     try:
         return not np.isnan(float(teststring))

--- a/src/semeio/fmudesign/design_distributions.py
+++ b/src/semeio/fmudesign/design_distributions.py
@@ -182,8 +182,8 @@ def draw_values_normal(
     dist_parameters: Sequence[str],
     numreals: int,
     rng: np.random.RandomState,
-    normalscoresamples: npt.NDArray[np.float64] | None = None,
-) -> npt.NDArray[np.float64]:
+    normalscoresamples: npt.NDArray[Any] | None = None,
+) -> npt.NDArray[Any]:
     status, msg = _check_dist_params_normal(dist_parameters)
 
     if not status:
@@ -226,8 +226,8 @@ def draw_values_lognormal(
     dist_parameters: Sequence[str],
     numreals: int,
     rng: np.random.RandomState,
-    normalscoresamples: npt.NDArray[np.float64] | None = None,
-) -> npt.NDArray[np.float64]:
+    normalscoresamples: npt.NDArray[Any] | None = None,
+) -> npt.NDArray[Any]:
     """Draws values from lognormal distribution.
     Args:
         dist_parameters(list): [mu, sigma] for the logarithm of the variable
@@ -263,8 +263,8 @@ def draw_values_uniform(
     dist_parameters: Sequence[str],
     numreals: int,
     rng: np.random.RandomState,
-    normalscoresamples: npt.NDArray[np.float64] | None = None,
-) -> npt.NDArray[np.float64]:
+    normalscoresamples: npt.NDArray[Any] | None = None,
+) -> npt.NDArray[Any]:
     """Draws values from uniform distribution.
     Args:
         dist_parameters(list): [minimum, maximum]
@@ -301,8 +301,8 @@ def draw_values_triangular(
     dist_parameters: Sequence[str],
     numreals: int,
     rng: np.random.RandomState,
-    normalscoresamples: npt.NDArray[np.float64] | None = None,
-) -> npt.NDArray[np.float64]:
+    normalscoresamples: npt.NDArray[Any] | None = None,
+) -> npt.NDArray[Any]:
     """Draws values from triangular distribution.
     Args:
         dist_parameters(list): [min, mode, max]
@@ -355,8 +355,8 @@ def draw_values_pert(
     dist_parameters: Sequence[str],
     numreals: int,
     rng: np.random.RandomState,
-    normalscoresamples: npt.NDArray[np.float64] | None = None,
-) -> npt.NDArray[np.float64]:
+    normalscoresamples: npt.NDArray[Any] | None = None,
+) -> npt.NDArray[Any]:
     """Draws values from pert distribution.
     Args:
         dist_parameters(list): [min, mode, max, scale]
@@ -416,8 +416,8 @@ def draw_values_loguniform(
     dist_parameters: Sequence[str],
     numreals: int,
     rng: np.random.RandomState,
-    normalscoresamples: npt.NDArray[np.float64] | None = None,
-) -> npt.NDArray[np.float64]:
+    normalscoresamples: npt.NDArray[Any] | None = None,
+) -> npt.NDArray[Any]:
     """Draws values from loguniform distribution.
     Args:
         dist_parameters(list): [minimum, maximum]
@@ -450,8 +450,8 @@ def draw_values(
     dist_parameters: Sequence[str],
     numreals: int,
     rng: np.random.RandomState,
-    normalscoresamples: npt.NDArray[np.float64] | None = None,
-) -> npt.NDArray[np.float64] | list[str] | str:
+    normalscoresamples: npt.NDArray[Any] | None = None,
+) -> npt.NDArray[Any] | list[str] | str:
     """
     Prepare scipy distributions with parameters
     Args:
@@ -508,8 +508,8 @@ def sample_discrete(
     dist_params: Sequence[str],
     numreals: int,
     rng: np.random.RandomState,
-    normalscoresamples: npt.NDArray[np.float64] | None = None,
-) -> tuple[bool, npt.NDArray[np.float64] | str]:
+    normalscoresamples: npt.NDArray[Any] | None = None,
+) -> tuple[bool, npt.NDArray[Any] | str]:
     status = True
     outcomes = re.split(",", dist_params[0])
     outcomes = [item.strip() for item in outcomes]

--- a/src/semeio/fmudesign/iman_conover.py
+++ b/src/semeio/fmudesign/iman_conover.py
@@ -27,10 +27,11 @@ Induce correlations
 """
 
 import numpy as np
+import numpy.typing as npt
 import scipy as sp
 
 
-def _is_positive_definite(X):
+def _is_positive_definite(X: npt.NDArray[np.float64]) -> bool:
     try:
         np.linalg.cholesky(X)
         return True
@@ -39,7 +40,7 @@ def _is_positive_definite(X):
 
 
 class ImanConover:
-    def __init__(self, correlation_matrix):
+    def __init__(self, correlation_matrix: npt.NDArray[np.float64]):
         """Create an Iman-Conover transform.
 
         Parameters
@@ -130,7 +131,7 @@ class ImanConover:
         self.C = correlation_matrix.copy()
         self.P = np.linalg.cholesky(self.C)
 
-    def __call__(self, X):
+    def __call__(self, X: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
         """Transform an input matrix X.
 
         The output will have the same marginal distributions, but with
@@ -203,7 +204,9 @@ class ImanConover:
         return result
 
 
-def decorrelate(X, remove_variance=True):
+def decorrelate(
+    X: npt.NDArray[np.float64], remove_variance: bool = True
+) -> npt.NDArray[np.float64]:
     """Removes correlations or covariance from data X.
 
     Examples

--- a/src/semeio/fmudesign/iman_conover.py
+++ b/src/semeio/fmudesign/iman_conover.py
@@ -26,12 +26,14 @@ Induce correlations
 0.279652...
 """
 
+from typing import Any
+
 import numpy as np
 import numpy.typing as npt
 import scipy as sp
 
 
-def _is_positive_definite(X: npt.NDArray[np.float64]) -> bool:
+def _is_positive_definite(X: npt.NDArray[Any]) -> bool:
     try:
         np.linalg.cholesky(X)
         return True
@@ -40,7 +42,7 @@ def _is_positive_definite(X: npt.NDArray[np.float64]) -> bool:
 
 
 class ImanConover:
-    def __init__(self, correlation_matrix: npt.NDArray[np.float64]):
+    def __init__(self, correlation_matrix: npt.NDArray[Any]):
         """Create an Iman-Conover transform.
 
         Parameters
@@ -131,7 +133,7 @@ class ImanConover:
         self.C = correlation_matrix.copy()
         self.P = np.linalg.cholesky(self.C)
 
-    def __call__(self, X: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    def __call__(self, X: npt.NDArray[Any]) -> npt.NDArray[Any]:
         """Transform an input matrix X.
 
         The output will have the same marginal distributions, but with
@@ -204,9 +206,7 @@ class ImanConover:
         return result
 
 
-def decorrelate(
-    X: npt.NDArray[np.float64], remove_variance: bool = True
-) -> npt.NDArray[np.float64]:
+def decorrelate(X: npt.NDArray[Any], remove_variance: bool = True) -> npt.NDArray[Any]:
     """Removes correlations or covariance from data X.
 
     Examples

--- a/src/semeio/forward_models/design2params/design2params.py
+++ b/src/semeio/forward_models/design2params/design2params.py
@@ -1,6 +1,7 @@
 import logging
 import warnings
 from pathlib import Path
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -24,13 +25,13 @@ logger = logging.getLogger(__name__)
 
 
 def run(
-    realization,
-    xlsfilename,
-    designsheetname="DesignSheet01",
-    defaultssheetname="DefaultValues",
-    parametersfilename="parameters.txt",
-    log_level=None,
-):
+    realization: int,
+    xlsfilename: str,
+    designsheetname: str = "DesignSheet01",
+    defaultssheetname: str = "DefaultValues",
+    parametersfilename: str = "parameters.txt",
+    log_level: int | str | None = None,
+) -> None:
     """
     Reads out all file content from different files and create dataframes
     """
@@ -68,8 +69,12 @@ def run(
 
 
 def _complete_parameters_file(
-    realization, parameters, parametersfilename, design_matrix_sheet, default_sheet
-):
+    realization: int,
+    parameters: pd.DataFrame,
+    parametersfilename: str,
+    design_matrix_sheet: pd.DataFrame,
+    default_sheet: pd.DataFrame,
+) -> None:
     """
     Pick key / values from chosen realization in design matrix
     Append those key / values if not present into parameters.txt
@@ -184,7 +189,13 @@ def _complete_parameters_file(
     )
 
 
-def _read_excel(file_name, sheet_name, header=0, usecols=None, engine=None):
+def _read_excel(
+    file_name: str,
+    sheet_name: str,
+    header: int = 0,
+    usecols: list[int] | None = None,
+    engine: Literal["xlrd", "openpyxl", "odf", "pyxlsb", "calamine"] | None = None,
+) -> pd.DataFrame:
     """
     Make dataframe from excel file
     :return: Dataframe
@@ -219,7 +230,7 @@ def _read_excel(file_name, sheet_name, header=0, usecols=None, engine=None):
     return dframe.dropna(axis=1, how="all")
 
 
-def _validate_design_matrix_header(design_matrix):
+def _validate_design_matrix_header(design_matrix: pd.DataFrame) -> None:
     """
     Validate header in user inputted design matrix
     :raises: ValueError if design matrix contains empty headers
@@ -239,7 +250,7 @@ def _validate_design_matrix_header(design_matrix):
         raise ValueError(f"Column headers not present in column {column_indexes}")
 
 
-def _invalid_design_realizations(design_matrix):
+def _invalid_design_realizations(design_matrix: pd.DataFrame) -> set[int]:
     """
     Build a set of realization indices where something is wrong,
     f.ex empty cells
@@ -292,7 +303,7 @@ def _invalid_design_realizations(design_matrix):
     return {cell_coord[0] for cell_coord in empty_cell_coords}
 
 
-def _read_defaultssheet(xlsfilename, defaultssheetname):
+def _read_defaultssheet(xlsfilename: str, defaultssheetname: str) -> pd.DataFrame:
     """
     Construct a dataframe of keys and values to be used as defaults from the
     first two columns in a spreadsheet.

--- a/src/semeio/forward_models/design_kw/design_kw.py
+++ b/src/semeio/forward_models/design_kw/design_kw.py
@@ -1,7 +1,9 @@
 import logging
 import re
 import shlex
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping, Sequence
+from re import Match
+from typing import Any
 
 from ert import ForwardModelStepWarning
 
@@ -60,7 +62,7 @@ def run(
 def find_matching_errors(
     line: str, template_file_name: str, template: list[str]
 ) -> list[str]:
-    errors = []
+    errors: list[str] = []
     for unmatched in unmatched_templates(line):
         if is_perl(template_file_name, template):
             _logger.warning(
@@ -79,22 +81,22 @@ def find_matching_errors(
     return errors
 
 
-def is_perl(file_name, template):
+def is_perl(file_name: str, template: Sequence[str]) -> bool:
     return file_name.endswith(".pl") or template[0].find("perl") != -1
 
 
-def is_xml(file_name: str, template: list[str]) -> bool:
+def is_xml(file_name: str, template: Sequence[str]) -> bool:
     return file_name.endswith(".xml") or template[0].find("?xml") != -1
 
 
-def unmatched_templates(line):
+def unmatched_templates(line: str) -> list[str]:
     bracketpattern = re.compile("<.+?>")
     if bracketpattern.search(line):
         return bracketpattern.findall(line)
     return []
 
 
-def is_comment(line):
+def is_comment(line: str) -> Match[str] | None:
     ecl_comment_pattern = re.compile("^--")
     std_comment_pattern = re.compile("^#")
     return ecl_comment_pattern.search(line) or std_comment_pattern.search(line)
@@ -116,8 +118,8 @@ def extract_key_value(parameters: list[str]) -> dict[str, str]:
     Raises:
         ValueError, with error messages and all unparsable lines.
     """
-    res = {}
-    errors = []
+    res: Mapping[str, str] = {}
+    errors: Sequence[str] = []
     for line in parameters:
         try:
             line_parts = shlex.split(line)
@@ -142,7 +144,10 @@ def extract_key_value(parameters: list[str]) -> dict[str, str]:
     return res
 
 
-def rm_genkw_prefix(paramsdict, ignoreprefixes="LOG10_"):
+def rm_genkw_prefix(
+    paramsdict: Mapping[str, Any],
+    ignoreprefixes: str | Iterable[str] | None = "LOG10_",
+) -> dict[str, Any]:
     """Strip prefixes from keys in a dictionary.
 
     Prefix is any string before a colon. No colon means no prefix.

--- a/src/semeio/forward_models/overburden_timeshift/ots_res_surface.py
+++ b/src/semeio/forward_models/overburden_timeshift/ots_res_surface.py
@@ -1,8 +1,10 @@
 import numpy as np
+import numpy.typing as npt
+from resdata.grid import Grid
 
 
 class OTSResSurface:
-    def __init__(self, grid, above=0):
+    def __init__(self, grid: Grid, above: float = 0):
         """
         Create a surface from a reservoir grid.
 
@@ -12,46 +14,46 @@ class OTSResSurface:
         :param above: Scalar: meters above most shallow active cell
         """
 
-        self._grid = grid
-        self._x = None
-        self._y = None
-        self._z = None
-        self._nx = None
-        self._ny = None
+        self._grid: Grid = grid
+        self._x: npt.NDArray[np.float32] | None = None
+        self._y: npt.NDArray[np.float32] | None = None
+        self._z: npt.NDArray[np.float32] | None = None
+        self._nx: int | None = None
+        self._ny: int | None = None
 
         self._calculate_surface(grid, above)
 
     @property
-    def x(self):
+    def x(self) -> npt.NDArray[np.float32] | None:
         return self._x
 
     @property
-    def y(self):
+    def y(self) -> npt.NDArray[np.float32] | None:
         return self._y
 
     @property
-    def z(self):
+    def z(self) -> npt.NDArray[np.float32] | None:
         return self._z
 
     @property
-    def nx(self):
+    def nx(self) -> int | None:
         return self._nx
 
     @property
-    def ny(self):
+    def ny(self) -> int | None:
         return self._ny
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.x)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"x: {self.x}\ny: {self.y}\nz: {self.z}"
 
     @property
-    def cell_corners(self):
+    def cell_corners(self) -> npt.NDArray[np.float32]:
         return self._get_top_corners()
 
-    def _calculate_surface(self, grid, above):
+    def _calculate_surface(self, grid: Grid, above: float) -> None:
         # calculate average from top face vecrtices
         # from unstructured grid as an interface between active and inactive cells
         nx, ny, nz = grid.getNX(), grid.getNY(), grid.getNZ()
@@ -82,7 +84,7 @@ class OTSResSurface:
         self._nx = nx
         self._ny = ny
 
-    def _get_top_corners(self):
+    def _get_top_corners(self) -> npt.NDArray[np.float32]:
         grid = self._grid
         nx = grid.getNX() + 1
         ny = grid.getNY() + 1

--- a/src/semeio/forward_models/overburden_timeshift/ots_vel_surface.py
+++ b/src/semeio/forward_models/overburden_timeshift/ots_vel_surface.py
@@ -3,7 +3,6 @@ from typing import Any, Literal
 import numpy as np
 import numpy.typing as npt
 import segyio
-from numpy import float64
 from scipy.interpolate import CloughTocher2DInterpolator
 from segyio import TraceField
 
@@ -73,9 +72,7 @@ class OTSVelSurface:
 
     def _read_velocity(
         self, vcube: str, cell_corners: npt.NDArray[Any]
-    ) -> tuple[
-        npt.NDArray[float64], npt.NDArray[float64], npt.NDArray[Any], int, float
-    ]:
+    ) -> tuple[npt.NDArray[Any], npt.NDArray[Any], npt.NDArray[Any], int, float]:
         """
         Read velocity from segy file. Upscale.
         :param vcube:

--- a/src/semeio/forward_models/rft/trajectory.py
+++ b/src/semeio/forward_models/rft/trajectory.py
@@ -1,9 +1,11 @@
 import os
+from typing import Self
 
 import pandas as pd
-from resdata.rft import ResdataRFTCell
+from resdata.rft import ResdataRFT, ResdataRFTCell
 
 from semeio.forward_models.rft.utility import strip_comments
+from semeio.forward_models.rft.zonemap import ZoneMap
 
 
 class TrajectoryPoint:
@@ -26,20 +28,27 @@ class TrajectoryPoint:
         zone (str)
     """
 
-    def __init__(self, utm_x, utm_y, measured_depth, true_vertical_depth, zone=None):
-        self.utm_x = utm_x
-        self.utm_y = utm_y
-        self.measured_depth = measured_depth
-        self.true_vertical_depth = true_vertical_depth
-        self.zone = zone
-        self.grid_ijk = None  # tuple
-        self.pressure = None
-        self.swat = None
-        self.sgas = None
-        self.soil = None
-        self.valid_zone = False
+    def __init__(
+        self,
+        utm_x: float,
+        utm_y: float,
+        measured_depth: float,
+        true_vertical_depth: float,
+        zone: str | None = None,
+    ):
+        self.utm_x: float = utm_x
+        self.utm_y: float = utm_y
+        self.measured_depth: float = measured_depth
+        self.true_vertical_depth: float = true_vertical_depth
+        self.zone: str | None = zone
+        self.grid_ijk: tuple[int, int, int] | None = None  # tuple
+        self.pressure: float | None = None
+        self.swat: float | None = None
+        self.sgas: float | None = None
+        self.soil: float | None = None
+        self.valid_zone: bool = False
 
-    def set_ijk(self, point):
+    def set_ijk(self, point: tuple[int, int, int]) -> None:
         """Set the ijk-tuple for the point, relating the UTM-coordinates to
         ijk-coordinates in a specific Eclipse grid.
 
@@ -48,7 +57,7 @@ class TrajectoryPoint:
         """
         self.grid_ijk = point
 
-    def validate_zone(self, zonemap=None):
+    def validate_zone(self, zonemap: ZoneMap | None = None) -> None:
         """Update the internal valid_zone property determining if
         the point can be validated. If the point is not initialized
         to be in a specific zone and has a well-defined k-index, the
@@ -64,7 +73,7 @@ class TrajectoryPoint:
                 self.zone, self.grid_ijk[2]
             )
 
-    def is_active(self):
+    def is_active(self) -> bool:
         """Determines if the point is regarded as active, and thus usable
         in a history match setting - meaning there is a simulated pressure
         value available and the zone is valid"""
@@ -72,7 +81,7 @@ class TrajectoryPoint:
             self.grid_ijk is not None and self.pressure is not None and self.valid_zone
         )
 
-    def inactive_info(self, zonemap=None):
+    def inactive_info(self, zonemap: ZoneMap | None = None) -> str | None:
         """Provides a string explaining why a point is not active.
 
         Returns None for active points.
@@ -92,13 +101,11 @@ class TrajectoryPoint:
                 return f"ZONEMAP_MISSING_VALUE {self!s} {self.grid_ijk[2]} {None}"
 
             return (
-                f"ZONE_MISMATCH {self!s} "
-                f"{self.grid_ijk[2]} "
-                f"{zonemap[self.grid_ijk[2]]}"
+                f"ZONE_MISMATCH {self!s} {self.grid_ijk[2]} {zonemap[self.grid_ijk[2]]}"
             )
         return None
 
-    def get_pressure(self):
+    def get_pressure(self) -> float:
         """Returns the simulated pressure for the point, or -1 if
         no simulated pressure is available
 
@@ -109,7 +116,7 @@ class TrajectoryPoint:
             return self.pressure
         return -1
 
-    def update_simdata_from_rft(self, rftfile):
+    def update_simdata_from_rft(self, rftfile: ResdataRFT) -> None:
         """Fetch simulated data from an Eclipse simulation by looking up
         binary RFT files. This requires the point to have the ijk-tuple
         set upfront.
@@ -136,7 +143,7 @@ class TrajectoryPoint:
                         # Two-phase Eclipse runs
                         self.soil = 1 - self.swat
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             f"(utm_x={self.utm_x}, "
             f"utm_y={self.utm_y}, "
@@ -151,16 +158,18 @@ class Trajectory:
         points (list): List of lists with (textual) data for the trajectory.
     """
 
-    def __init__(self, points):
-        self.trajectory_points = [TrajectoryPoint(*point) for point in points]
+    def __init__(self, points: list[list[float | str | None]]):
+        self.trajectory_points: list[TrajectoryPoint] = [
+            TrajectoryPoint(*point) for point in points
+        ]
 
-    def __getitem__(self, i):
+    def __getitem__(self, i: int) -> TrajectoryPoint:
         return self.trajectory_points[i]
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.trajectory_points)
 
-    def to_dataframe(self, zonemap=None):
+    def to_dataframe(self, zonemap: ZoneMap | None = None) -> pd.DataFrame:
         """Expose the trajectory data as a Pandas DataFrame.
 
         The data grid_ijk in self is a tuple, this is split into three distinct
@@ -204,7 +213,11 @@ class Trajectory:
         return dframe.dropna(how="all", axis="columns")
 
     @staticmethod
-    def split_tuple_column(dframe, tuplecolumn="grid_ijk", components=None):
+    def split_tuple_column(
+        dframe: pd.DataFrame,
+        tuplecolumn: str = "grid_ijk",
+        components: list[str] | None = None,
+    ) -> pd.DataFrame:
         """For a dataframe with a column containing a tuple
         datatype, split the tuple into the components [I, J, K] as new columns.
 
@@ -244,7 +257,7 @@ class Trajectory:
         )
 
     @staticmethod
-    def parse_trajectory_line(line):
+    def parse_trajectory_line(line: str) -> list[float | str | None]:
         """Reads a text line with four floating point values (utm_x, utm_y, md, and tvd)
         and an optional string being the zone name.
 
@@ -271,9 +284,9 @@ class Trajectory:
         return [*floats, zone]
 
     @classmethod
-    def load_from_file(cls, filepath):
+    def load_from_file(cls, filepath: str) -> Self:
         """Initialize a Trajectory from a text file describing a well path."""
-        trajectory_points = []
+        trajectory_points: list[list[float | str | None]] = []
 
         filename = os.path.join(filepath)
         if not os.path.isfile(filename):

--- a/src/semeio/forward_models/rft/utility.py
+++ b/src/semeio/forward_models/rft/utility.py
@@ -8,11 +8,11 @@ from resdata.grid import Grid
 from resdata.rft import ResdataRFTFile
 
 
-def strip_comments(line):
+def strip_comments(line: str) -> str:
     return line.partition("--")[0].rstrip()
 
 
-def existing_directory(path):
+def existing_directory(path: str) -> str:
     if not os.path.isdir(path):
         raise argparse.ArgumentTypeError(
             f"The path {path} is not an existing directory"
@@ -38,7 +38,7 @@ def load_and_parse_well_time_file(
     if not Path(filename).exists():
         raise argparse.ArgumentTypeError(f"The path {filename} does not exist")
 
-    well_times = []
+    well_times: list[tuple[str, datetime.date, int]] = []
     base_error_msg = (
         "Line {line_number} in well_and_time_file {filename} not on proper format: "
     )
@@ -112,7 +112,7 @@ def load_and_parse_well_time_file(
     return well_times
 
 
-def valid_eclbase(file_path):
+def valid_eclbase(file_path: str) -> tuple[Grid, ResdataRFTFile]:
     """
     The filename is assumed to be without extension and two files
     must be present, <filename>.RFT and <filename>.EGRID.

--- a/src/semeio/forward_models/rft/zonemap.py
+++ b/src/semeio/forward_models/rft/zonemap.py
@@ -1,5 +1,7 @@
 import argparse
 import os
+from collections.abc import Mapping
+from typing import Any, Self
 
 from semeio.forward_models.rft.utility import strip_comments
 
@@ -17,9 +19,9 @@ class ZoneMap:
             of strings with zone names.
     """
 
-    def __init__(self, zones_at_k_value=None):
-        self._zones_at_k_value = zones_at_k_value or {}
-        self._k_values_at_zone = {}
+    def __init__(self, zones_at_k_value: Mapping[int, Any] | None = None):
+        self._zones_at_k_value: Mapping[int, Any] | None = zones_at_k_value or {}
+        self._k_values_at_zone: Mapping[str, Any] = {}
 
         # Construct a reverse dictionary for the reverse
         # lookup _k_values_at_zone
@@ -31,7 +33,7 @@ class ZoneMap:
                 self._k_values_at_zone[zone_name].append(k_value)
 
     @classmethod
-    def load_and_parse_zonemap_file(cls, filename):
+    def load_and_parse_zonemap_file(cls, filename: str) -> Self | None:
         # The forward model description files used in ERT does not allow
         # for optional arguments. If the user has not specified
         # a value in their configuration, the forward model description
@@ -42,7 +44,7 @@ class ZoneMap:
         if not os.path.isfile(filename):
             raise argparse.ArgumentTypeError(f"ZoneMap file {filename} not found!")
 
-        zones_at_k_value = {}
+        zones_at_k_value: dict[int, Any] = {}
 
         with open(filename, encoding="utf-8") as file_handle:
             zonemap_lines = file_handle.readlines()
@@ -85,19 +87,19 @@ class ZoneMap:
 
         return cls(zones_at_k_value)
 
-    def __contains__(self, item):
+    def __contains__(self, item: Any) -> bool:
         if isinstance(item, int):
             return item in self._zones_at_k_value
         if isinstance(item, str):
             return item in self._k_values_at_zone
         return False
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: Any) -> Any:
         if isinstance(item, int):
             return self._zones_at_k_value[item]
         if isinstance(item, str):
             return self._k_values_at_zone[item]
         raise KeyError(f"{item} is neither a k value nor a zone")
 
-    def has_relationship(self, zone, k):
+    def has_relationship(self, zone: str, k: Any) -> bool:
         return k in self._k_values_at_zone.get(zone, [])

--- a/src/semeio/forward_models/scripts/fm_pyscal.py
+++ b/src/semeio/forward_models/scripts/fm_pyscal.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import os
 import sys
+from typing import Literal
 
 from pyscal import pyscalcli
 
@@ -143,14 +144,14 @@ def _get_args_parser():
 
 
 def run(
-    relperm_parameters_file,
-    output_filename,
-    sheet_name,  # string, use 0 or __NONE__ when irrelevant or default
-    int_param_wo_name,  # string or __NONE__
-    int_param_go_name,  # string or __NONE__
-    slgof,  # sgof or slgof, default sgof
-    family,  # int: 1 or 2, default 1
-    parameters_file_name="parameters.txt",
+    relperm_parameters_file: str,
+    output_filename: str,
+    sheet_name: str | None,  # string, use 0 or __NONE__ when irrelevant or default
+    int_param_wo_name: str,  # string or __NONE__
+    int_param_go_name: str,  # string or __NONE__
+    slgof: str,  # sgof or slgof, default sgof
+    family: Literal[1] | Literal[2],  # int: 1 or 2, default 1
+    parameters_file_name: str = "parameters.txt",
 ):
     """This function is a wrapper around the Pyscal command
     line tool. The command line tool is designed around argparse
@@ -223,8 +224,10 @@ def run(
 
 
 def _get_interpolation_values(
-    int_param_wo_name, int_param_go_name, parameters_file_name="parameters.txt"
-):
+    int_param_wo_name: str,
+    int_param_go_name: str,
+    parameters_file_name: str = "parameters.txt",
+) -> tuple[float, float]:
     """
     Given parameter names, obtain values to interpolate through from parameters.txt
 

--- a/src/semeio/hook_implementations/forward_models.py
+++ b/src/semeio/hook_implementations/forward_models.py
@@ -1,4 +1,5 @@
 import importlib
+from typing import Any
 
 import ert
 import importlib_resources
@@ -47,11 +48,13 @@ def _get_forward_models_from_directory(directory: str) -> dict[str, str]:
 
 
 @ert.plugin(name="semeio")
-def installable_jobs():
+def installable_jobs() -> dict[str, str]:
     return _get_forward_models_from_directory("forward_models/config")
 
 
-def _get_module_variable_if_exists(module_name, variable_name, default=""):
+def _get_module_variable_if_exists(
+    module_name: str, variable_name: str, default: str = ""
+) -> Any:
     try:
         script_module = importlib.import_module(module_name)
     except ImportError:
@@ -61,7 +64,7 @@ def _get_module_variable_if_exists(module_name, variable_name, default=""):
 
 
 @ert.plugin(name="semeio")
-def job_documentation(job_name):
+def job_documentation(job_name: str) -> dict[str, Any] | None:
     forward_model_name = job_name
     semeio_forward_models = set(installable_jobs().data.keys())
     if forward_model_name not in semeio_forward_models:

--- a/src/semeio/workflows/ahm_analysis/ahmanalysis.py
+++ b/src/semeio/workflows/ahm_analysis/ahmanalysis.py
@@ -393,7 +393,7 @@ def calc_observationsgroup_misfit(
     obs_keys: str,
     df_update_log: pd.DataFrame,
     misfit_df: pd.DataFrame,
-) -> pd.Series[float] | float:
+) -> "pd.Series[float] | float":
     """To get the misfit for total observations (active/inactive)."""
 
     total_obs_nr = len(df_update_log[df_update_log.status.isin(["Active", "Inactive"])])

--- a/src/semeio/workflows/ahm_analysis/ahmanalysis.py
+++ b/src/semeio/workflows/ahm_analysis/ahmanalysis.py
@@ -124,7 +124,7 @@ class AhmAnalysisJob(ErtScript):
         random_seed: int,
         reports_dir: str,
         ensemble: Ensemble | None,
-    ) -> Any:
+    ) -> None:
         """Perform analysis of parameters change per obs group
         prior to posterior of ahm"""
 
@@ -357,7 +357,7 @@ def _run_ministep(
     )
 
 
-def make_obs_groups(key_map):
+def make_obs_groups(key_map: dict[str, Any]) -> dict[str, Any]:
     """Create a mapping of observation groups, the names will be:
     data_key -> [obs_keys] and All_obs-{missing_obs} -> [obs_keys]
     and All_obs -> [all_obs_keys]
@@ -383,13 +383,17 @@ def make_obs_groups(key_map):
     return combinations
 
 
-def count_active_observations(df_update_log):
+def count_active_observations(df_update_log: pd.DataFrame) -> int:
     """To get the active observation info."""
     df_active = df_update_log[(df_update_log["status"] == "Active")]
     return len(df_active)
 
 
-def calc_observationsgroup_misfit(obs_keys, df_update_log, misfit_df):
+def calc_observationsgroup_misfit(
+    obs_keys: str,
+    df_update_log: pd.DataFrame,
+    misfit_df: pd.DataFrame,
+) -> pd.Series[float] | float:
     """To get the misfit for total observations (active/inactive)."""
 
     total_obs_nr = len(df_update_log[df_update_log.status.isin(["Active", "Inactive"])])
@@ -411,7 +415,9 @@ def calc_observationsgroup_misfit(obs_keys, df_update_log, misfit_df):
     return mean.mean()
 
 
-def _filter_on_prefix(list_of_strings, prefixes):
+def _filter_on_prefix(
+    list_of_strings: Iterable[str], prefixes: Iterable[str]
+) -> set[str]:
     """returns the set of strings that has a match for any of the given prefixes"""
     return {
         string
@@ -420,7 +426,9 @@ def _filter_on_prefix(list_of_strings, prefixes):
     }
 
 
-def get_updated_parameters(prior_data, parameters):
+def get_updated_parameters(
+    prior_data: pd.DataFrame, parameters: Iterable[str]
+) -> list[str]:
     """make list of updated parameters
     (excluding duplicate transformed parameters)
     """
@@ -428,7 +436,7 @@ def get_updated_parameters(prior_data, parameters):
         list_of_strings=prior_data.keys(), prefixes=parameters
     )
     # remove parameters with constant prior distribution
-    p_keysf = []
+    p_keysf: list[str] = []
     for dkey in parameter_keys:
         if prior_data[dkey].ndim > 1:
             warnings.warn(
@@ -443,16 +451,20 @@ def get_updated_parameters(prior_data, parameters):
     return p_keysf
 
 
-def calc_kolmogorov_smirnov(columns, prior_data, target_data):
+def calc_kolmogorov_smirnov(
+    columns: Iterable[str],
+    prior_data: pd.DataFrame,
+    target_data: pd.DataFrame,
+) -> dict[str, float]:
     """Calculate kolmogorov_smirnov matrix"""
-    ks_param = {}
+    ks_param: dict[str, float] = {}
     for dkey in sorted(columns):
         ks_val = ks_2samp(prior_data[dkey], target_data[dkey])
         ks_param[dkey] = ks_val[0]
     return ks_param
 
 
-def raise_if_empty(dataframes, messages):
+def raise_if_empty(dataframes: Iterable[pd.DataFrame], messages: Iterable[str]) -> None:
     """Check input ensemble prior is not empty
     and if ensemble contains parameters for hm"""
     for dframe in dataframes:

--- a/src/semeio/workflows/csv_export2/csv_export2.py
+++ b/src/semeio/workflows/csv_export2/csv_export2.py
@@ -1,5 +1,7 @@
 import argparse
 import sys
+from collections.abc import Iterable
+from typing import Any
 
 import pandas as pd
 from ert import ErtScript, plugin
@@ -70,7 +72,12 @@ runs::
 """
 
 
-def csv_exporter(runpathfile, time_index, outputfile, column_keys=None):
+def csv_exporter(
+    runpathfile: str,
+    time_index: str,
+    outputfile: str,
+    column_keys: Iterable[str] | None = None,
+) -> None:
     """Export CSV data (summary and parameters) from an EnsembleSet
 
     The EnsembleSet is described by a runpathfile which must exists
@@ -91,11 +98,11 @@ def csv_exporter(runpathfile, time_index, outputfile, column_keys=None):
 
 
 class CsvExport2Job(ErtScript):
-    def run(self, *args, **_):
+    def run(self, *args: Any, **_) -> None:
         main(args)
 
 
-def main(args):
+def main(args: Any) -> None:
     parser = csv_export_parser()
     args = parser.parse_args(args)
 
@@ -142,7 +149,7 @@ def csv_export_parser():
 
 
 @plugin(name="semeio")
-def legacy_ertscript_workflow(config):
+def legacy_ertscript_workflow(config: Any) -> None:
     workflow = config.add_workflow(CsvExport2Job, "CSV_EXPORT2")
     workflow.parser = csv_export_parser
     workflow.description = DESCRIPTION
@@ -150,5 +157,5 @@ def legacy_ertscript_workflow(config):
     workflow.category = "export"
 
 
-def cli():
+def cli() -> None:
     main(sys.argv[1:])


### PR DESCRIPTION
Closes #709 

This PR adds type annotations mainly to the function/method signatures. In some cases, some type annotations in the body is added. Also added a `py.typed` file that should be included in the package manifest, [see more info here](https://typing.python.org/en/latest/spec/distributing.html#packaging-type-information). [`basedpyright`](https://docs.basedpyright.com/latest/benefits-over-pyright/baseline/) was used to analyze the codebase. I see that this has introduced a set of type violations that was already present in the repo.

I also noticed that docstrings used multiple formats, and not always was up to date with the actual signature. I would suggest adding [`pydoclint`](https://docs.astral.sh/ruff/rules/#pydoclint-doc) as a Ruff rule to keep docstrings consistent and updated

I have really no knowledge of this repo, so please feel free to correct me if i made any mistakes :)