### PR TITLE
Remove return in test to silence pytest warning

### DIFF
--- a/tests/fmudesign/test_use_cases.py
+++ b/tests/fmudesign/test_use_cases.py
@@ -149,5 +149,3 @@ def test_constant_distribution(tmpdir, monkeypatch, gen_input_sheet):
     print(f"Parameter 'a' values: {set(design.designvalues['a'])}")
     print(f"Number of realizations: {len(design.designvalues)}")
     print(f"Sensitivity name: {set(design.designvalues['SENSNAME'])}")
-
-    return design


### PR DESCRIPTION
```
PytestReturnNotNoneWarning: Expected None, but tests/fmudesign/test_use_cases.py::
test_constant_distribution[general_input] 
returned <semeio.fmudesign.create_design.DesignMatrix object at 0x000001DC7AF76CF0>, which will be 
an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
```