### PR TITLE
Seed all random number generators in testing

### DIFF
--- a/tests/fmudesign/test_design_distributions.py
+++ b/tests/fmudesign/test_design_distributions.py
@@ -79,8 +79,9 @@ def test_draw_values_pert(seed):
     assert np.isclose(values.mean(), 5, atol=0.55)
 
 
-def test_sample_discrete():
-    rng = np.random.default_rng()
+@pytest.mark.parametrize("seed", range(100))
+def test_sample_discrete(seed):
+    rng = np.random.default_rng(seed)
 
     outcomes = ["foo", "bar.com"]
     # Test basic functionality
@@ -97,16 +98,17 @@ def test_sample_discrete():
 
     # Test weights that don't sum to 1
     weighted_values = dists.sample_discrete(
-        [",".join(outcomes), "2,6"], rng.uniform(size=100)
+        [",".join(outcomes), "2,6"], rng.uniform(size=1000)
     )
     # Should see roughly 25% foo and 75% bar.com
     foo_count = np.sum(weighted_values == "foo")
-    assert 15 <= foo_count <= 35  # Allow some variance due to randomness
+    assert 200 <= foo_count <= 300  # Allow some variance due to randomness
 
 
-def test_draw_values():
+@pytest.mark.parametrize("seed", range(100))
+def test_draw_values(seed):
     """Test the wrapper function for drawing values"""
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(seed)
 
     quantiles = rng.uniform(size=10)
 

--- a/tests/forward_models/pyscal/test_pyscal.py
+++ b/tests/forward_models/pyscal/test_pyscal.py
@@ -44,6 +44,8 @@ EXAMPLE_WATEROIL = pd.DataFrame(columns=["SATNUM", "Nw", "NOW"], data=[[1, 2, 2]
 )
 def test_fm_pyscal(dframe, runargs, tmpdir):
     """Parametrized test function for fm_pyscal"""
+    random.seed(42)
+
     tmpdir.chdir()
     dframe.to_csv("relperm-input.csv", index=False)
 


### PR DESCRIPTION
Using RNG without seeds causes tests to fail every now and then. To test statistical properties, it is better to see the rng and test on many seeds. That way we can replicate across machines and we don't have to be stopped by false positives (what looks like test failures are just a bad rng). 