### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -13,6 +13,8 @@ env:
 jobs:
   type-checking:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 15
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/semeio/security/code-scanning/5](https://github.com/equinor/semeio/security/code-scanning/5)

The best way to fix this problem is to specify the job's permissions so that the GITHUB_TOKEN granted to each job only has the minimal required access, rather than inheriting potentially dangerous repository defaults. Since this workflow does not require write access to the repository or any other special privileges, the optimal fix is to add a `permissions:` block to the job definition for `type-checking` (line 15), setting `contents: read`. This can be done by inserting:

```yaml
permissions:
  contents: read
```

immediately after line 15 (under `type-checking:`), before any steps. No new packages or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
