### PR TITLE
Fix escaping of newline

### DIFF
--- a/src/semeio/forward_models/__init__.py
+++ b/src/semeio/forward_models/__init__.py
@@ -230,14 +230,14 @@ class InsertNoSim(ForwardModelStepPlugin):
                 "sed",
                 "-i",
                 "",
-                "s/^RUNSPEC.*/RUNSPEC\\\\nNOSIM/",
+                r"s/^RUNSPEC.*/RUNSPEC\nNOSIM/",
                 "<ECLBASE>.DATA",
             ]
             if sys.platform == "darwin"
             else [
                 "sed",
                 "-i",
-                "s/^RUNSPEC.*/RUNSPEC\\\\nNOSIM/",
+                r"s/^RUNSPEC.*/RUNSPEC\nNOSIM/",
                 "<ECLBASE>.DATA",
             ],
         )


### PR DESCRIPTION
Goes with https://github.com/equinor/ert/pull/12056

Four slashes previously worked with ERT due to being serialized through @dataclasses.dataclass custom __post_init__, wherein it ate up 2 of the slashes, leading to \\n in the joblist.json. When changing ForwardModelStep to a pydantic basemodel, it goes from eating 2 slashes to preserving all 4. Hence, for pydantic to work, we need to use a single escaped \n in INSERT_NOSIM.