### PR TITLE
Fix bug when all corr entries are 1

### DIFF
--- a/src/semeio/fmudesign/create_design.py
+++ b/src/semeio/fmudesign/create_design.py
@@ -902,7 +902,7 @@ class MonteCarloSensitivity(Sensitivity):
                     print("  - The matrix must be positive semi-definite")
                     print("\nInput correlation matrix:")
                     print_corrmat(df_correlations)
-                    df_correlations.values[:] = nearest
+                    df_correlations.loc[:] = nearest
                     print("\nAdjusted to nearest consistent correlation matrix:")
                     print_corrmat(df_correlations)
 

--- a/src/semeio/fmudesign/quality_report.py
+++ b/src/semeio/fmudesign/quality_report.py
@@ -394,7 +394,7 @@ def print_corrmat(df_corrmat: pd.DataFrame) -> None:
     values = df_corrmat.to_numpy()
     mask = np.isclose(values, 0)
     values[mask] = np.abs(values[mask])
-    df_corrmat.values[:] = values
+    df_corrmat.loc[:] = values
 
     # Remove upper triangular part for prettier printing
     formatter = lambda x: np.format_float_positional(


### PR DESCRIPTION
This was due to dataframe assignments using df.values[:] = ... instead of df.loc[:] = ... . The former works *sometimes*, but not always.

```python3
In [87]: df = pd.DataFrame([[1.0, 1], [1.0, 1]])

In [88]: df
Out[88]: 
     0  1
0  1.0  1
1  1.0  1

In [89]: df.values[:] = np.zeros((2,2))

In [90]: df
Out[90]: 
     0  1
0  1.0  1
1  1.0  1

In [91]: df = pd.DataFrame([[1.0, 1], [1.0, 1]])

In [92]: df.loc[:] = np.zeros((2,2))

In [93]: df
Out[93]: 
     0  1
0  0.0  0
1  0.0  0

In [94]: df = pd.DataFrame([[1.0, 1.0], [1.0, 1.0]])

In [95]: df.values[:] = np.zeros((2,2))

In [96]: df
Out[96]: 
     0    1
0  0.0  0.0
1  0.0  0.0
```