### PR TITLE
Create consistent path objects

### DIFF
--- a/src/semeio/fmudesign/_designsummary.py
+++ b/src/semeio/fmudesign/_designsummary.py
@@ -15,7 +15,7 @@ def summarize_design(filename: str, sheetname: str = "DesignSheet01") -> pd.Data
      specified in a design matrix on standard fmu format.
 
     Args:
-        filename (str): Path to excel or csv file containing designmatrix
+        filename (str): Name of excel or csv file containing designmatrix
             for one by one sensitivities on standard FMU format.
         sheetname (str): Name of sheet in excel workbook which
             contains the designmatrix (only for excel input). Defaults to

--- a/src/semeio/fmudesign/_excel_to_dict.py
+++ b/src/semeio/fmudesign/_excel_to_dict.py
@@ -78,7 +78,7 @@ def inputdict_to_yaml(inputdict: Mapping[str, Any], filename: str) -> None:
 
     Args:
         inputdict (dict)
-        filename (str): path for where to write file
+        filename (str): name of output file
     """
     with open(filename, "w", encoding="utf-8") as stream:
         yaml.dump(inputdict, stream)
@@ -148,7 +148,7 @@ def _check_for_mixed_sensitivities(sens_name: str, sens_group: pd.DataFrame) -> 
 
 
 def resolve_path(input_filename: str, reference: str) -> str:
-    """The path `input_filename` is an Excel sheet, and `reference` is a cell
+    """The file `input_filename` is an Excel sheet, and `reference` is a cell
     value that *might* be a reference to another file. Resolve the path to
     `reference` and return.
     """
@@ -178,7 +178,7 @@ def _excel_to_dict_onebyone(
     """Reads configuration from Excel file for a onebyone design matrix.
 
     Args:
-        input_filename (str): path to excel workbook
+        input_filename (str): Name of excel workbook
         general_input_sheet (str): name of general input sheet
         design_input_sheet (str): name of design input sheet
         default_values_sheet (str): name of default value sheet
@@ -366,7 +366,7 @@ def _read_defaultvalues(filename: str, sheetname: str) -> dict[str, Any]:
     reference/base case
 
     Args:
-        filename (str): path to excel file
+        filename (str): Name of excel file
         sheetname (string): name of defaultsheet
 
     Returns:
@@ -403,7 +403,7 @@ def _read_dependencies(
     """Reads parameters that are set from other parameters
 
     Args:
-        filename(path): path to excel file
+        filename(str): name of excel file
         sheetname (string): name of dependency sheet
         from_parameter (string): parameter name to map from
 
@@ -437,7 +437,7 @@ def _read_background(inp_filename: str, bck_sheet: str) -> dict[str, Any]:
     """Reads excel sheet with background parameters and distributions
 
     Args:
-        inp_filename (path): path to Excel workbook
+        inp_filename (str): name of Excel workbook
         bck_sheet (str): name of sheet with background parameters
 
     Returns:

--- a/src/semeio/fmudesign/create_design.py
+++ b/src/semeio/fmudesign/create_design.py
@@ -280,8 +280,8 @@ class DesignMatrix:
         # Create folder for output file
         Path(filename).parent.mkdir(exist_ok=True, parents=True)
 
-        if Path(filename).suffix != ".xlsx":
-            filename = Path(filename).stem + ".xlsx"
+        if not filename.endswith(".xlsx"):
+            filename = filename + ".xlsx"
             print(f"Warning: Missing .xlsx suffix. Changed to: {filename}")
 
         xlsxwriter = pd.ExcelWriter(filename, engine="openpyxl")
@@ -324,7 +324,7 @@ class DesignMatrix:
             seeds: Seed configuration. Can be:
                 - "None" or None: Sets seedvalues to None
                 - "default": Generates sequential seeds starting from 1000
-                - str that represents a path to an existing file
+                - str: Name of file that cointains seeds
             max_reals: Maximum number of seed values to generate or load
         """
         if seeds in {None, "None"}:
@@ -825,7 +825,7 @@ class MonteCarloSensitivity(Sensitivity):
             parameters (dict): dictionary of parameters and distributions
             seeds (str): default or None
             corrdict (dict): Configuration for correlated parameters. Contains:
-                - 'inputfile': Path to Excel file with correlation matrices
+                - 'inputfile': Name of Excel file with correlation matrices
                 - 'sheetnames': List of sheet names, where each sheet contains a correlation matrix
                 If None, parameters are treated as uncorrelated.
             rng (numpy.random.Generator): Random number generator instance
@@ -993,7 +993,7 @@ class ExternSensitivity(Sensitivity):
 
         Args:
             realnums (list): list of integers with realization numbers
-            filename (str): path where to read values from
+            filename (str): file to read values from
             parameters (list): list with parameter names
             seeds (str): default or None
         """

--- a/src/semeio/fmudesign/design_distributions.py
+++ b/src/semeio/fmudesign/design_distributions.py
@@ -1,7 +1,6 @@
 """Module for random sampling of parameter values from distributions."""
 
 from collections.abc import Sequence
-from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -191,7 +190,7 @@ def is_number(teststring: str) -> bool:
         return False
 
 
-def read_correlations(excel_filename: str | Path, corr_sheet: str) -> pd.DataFrame:
+def read_correlations(excel_filename: str, corr_sheet: str) -> pd.DataFrame:
     """Read a correlation matrix from an Excel sheet.
 
     The sheet must have rows/columns with variable names. They must match.
@@ -199,7 +198,7 @@ def read_correlations(excel_filename: str | Path, corr_sheet: str) -> pd.DataFra
     must be specified.
 
     Args:
-        excel_filename (str or Path): Path to Excel file containing correlation matrix
+        excel_filename (str): name of Excel file containing correlation matrix
         corr_sheet (str): name of sheet containing correlation matrix
 
     Returns:

--- a/src/semeio/fmudesign/utils.py
+++ b/src/semeio/fmudesign/utils.py
@@ -14,7 +14,7 @@ def parameters_from_extern(filename: str) -> pd.DataFrame:
     or csv.
 
     Args:
-        filename (str): path to file
+        filename (str): name of file
     """
     if str(filename).endswith(".xlsx"):
         return (
@@ -39,7 +39,7 @@ def seeds_from_extern(filename: str, max_reals: int) -> list[int]:
     or csv.
 
     Args:
-        filename (str): path to file
+        filename (str): name of file
     """
     if str(filename).endswith(".xlsx"):
         df_seeds = (


### PR DESCRIPTION
We implement the following logic:

- Filenames: represented as strings and treated as such.
- Directories: represented as Path objects and treated as such.  