### PR TITLE
Fix bug where flags before file failed

### DIFF
--- a/src/semeio/fmudesign/fmudesignrunner.py
+++ b/src/semeio/fmudesign/fmudesignrunner.py
@@ -294,14 +294,12 @@ def main() -> None:
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     warnings.filterwarnings("ignore", category=FutureWarning)
 
-    parser, subparsers = get_parser()
+    parser, _subparsers = get_parser()
 
-    # Backwards compatibility. If not a known command and a file, assume "run"
-    if len(sys.argv) > 1:
-        unknown_cmnd = sys.argv[1] not in subparsers.choices
-        file_cmd = sys.argv[1].endswith((".xlsx",))
-        if unknown_cmnd and file_cmd:
-            sys.argv.insert(1, "run")
+    # Backwards compatibility. If not a known command, assume "run"
+    valid_cmds = ("run", "init", "-h", "--help", "-v", "--version")
+    if len(sys.argv) > 1 and sys.argv[1] not in valid_cmds:
+        sys.argv.insert(1, "run")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This failed backwards compatibility:
```
fmudesign --designinput sheet1 file.xlsx
```
While this worked:
```
fmudesign file.xlsx --designinput sheet1
```

Fix so that "run" is preprended in both cases.