### PR TITLE
Pass script_runner.run() arguments as a sequence

### DIFF
--- a/tests/test_console_scripts.py
+++ b/tests/test_console_scripts.py
@@ -19,5 +19,5 @@ def test_console_scripts_help(script_runner, entry_point):
     by checking that we call call --help (which all these have). Semeio
     must be installed for them to pass.
     """
-    ret = script_runner.run(entry_point, "--help")
+    ret = script_runner.run([entry_point, "--help"])
     assert ret.success

--- a/tests/test_ert_integration.py
+++ b/tests/test_ert_integration.py
@@ -37,7 +37,7 @@ def test_console_scripts_exit_code(script_runner, entry_point, options):
     fail when the same script is called as a FORWARD_MODEL, without relying on
     ERTs TARGET_FILE mechanism for determining failure.
     """
-    assert script_runner.run(entry_point, options).returncode != 0
+    assert script_runner.run([entry_point, options]).returncode != 0
 
 
 @pytest.mark.ert_integration


### PR DESCRIPTION
pytest-console-scripts deprecated passing the command and its arguments as separate positional arguments in favor of a single sequence. Updates the two call sites in tests/test_ert_integration.py and tests/test_console_scripts.py to the new form.

Closes #893