### PR TITLE
Simplify string matching in error message

### DIFF
--- a/tests/forward_models/overburden_timeshift/test_ots.py
+++ b/tests/forward_models/overburden_timeshift/test_ots.py
@@ -64,7 +64,7 @@ def fixture_set_up(tmp_path):
     [
         ("TEST.INIT", "TEST.INIT"),
         ("TEST.EGRID", "Loading grid from:.*TEST.EGRID failed"),
-        ("TEST.UNRST", 'Failed to open file ".*TEST.UNRST"'),
+        ("TEST.UNRST", ".*TEST.UNRST.*"),
     ],
 )
 @pytest.mark.usefixtures("setup_tmpdir")


### PR DESCRIPTION
Makes the test compatible with both resdata 6.x and 7.x