### PR TITLE
Speed up test

### DIFF
--- a/tests/test_console_scripts.py
+++ b/tests/test_console_scripts.py
@@ -1,24 +1,34 @@
+from importlib.metadata import entry_points
+
 import pytest
+
+EXPECTED_ENTRYPOINTS = {
+    "csv_export2",
+    "overburden_timeshift",
+    "design2params",
+    "fmudesign",
+    "gendata_rft",
+    "design_kw",
+    "fm_pyscal",
+    "replace_string",
+}
 
 
 @pytest.mark.integration_test
-@pytest.mark.script_launch_mode("subprocess")
-@pytest.mark.parametrize(
-    "entry_point",
-    [
-        "csv_export2",
-        "overburden_timeshift",
-        "design2params",
-        "gendata_rft",
-        "design_kw",
-        "fm_pyscal",
-    ],
-)
-def test_console_scripts_help(script_runner, entry_point):
-    """
-    This test is a quick test that the scripts are installed correctly,
-    by checking that we call call --help (which all these have). Semeio
-    must be installed for them to pass.
-    """
-    ret = script_runner.run([entry_point, "--help"])
-    assert ret.success
+def test_that_console_scripts_are_installed_and_their_help_command_returns_exit_code_0(
+    monkeypatch,
+):
+    semeio_entry_points = [
+        e
+        for e in iter(entry_points(group="console_scripts"))
+        if e.value.startswith("semeio.")
+    ]
+
+    semeio_entry_point_names = {e.name for e in semeio_entry_points}
+    assert semeio_entry_point_names == EXPECTED_ENTRYPOINTS
+
+    for entrypoint in semeio_entry_points:
+        func = entrypoint.load()
+        monkeypatch.setattr("sys.argv", [entrypoint.name, "--help"])
+        with pytest.raises(SystemExit, match="0"):
+            func()

--- a/tests/test_console_scripts.py
+++ b/tests/test_console_scripts.py
@@ -30,5 +30,6 @@ def test_that_console_scripts_are_installed_and_their_help_command_returns_exit_
     for entrypoint in semeio_entry_points:
         func = entrypoint.load()
         monkeypatch.setattr("sys.argv", [entrypoint.name, "--help"])
-        with pytest.raises(SystemExit, match="0"):
+        with pytest.raises(SystemExit) as system_exit:
             func()
+        assert system_exit.value.code == 0


### PR DESCRIPTION
This test used to create a subprocess for each entry point, which made every test case use >4seconds, totalling in >30sec total time.

The new solution will run all entry points in the same pytest process, and will dynamically detect all semeio entry points and assert that these match with the ones we expect to exist.

Benchmark locally:
`pytest tests/test_console_scripts.py --durations=0`
Before:
```
5.17s call     tests/test_console_scripts.py::test_console_scripts_help[subprocess-overburden_timeshift]
4.79s call     tests/test_console_scripts.py::test_console_scripts_help[subprocess-fm_pyscal]
4.73s call     tests/test_console_scripts.py::test_console_scripts_help[subprocess-gendata_rft]
4.72s call     tests/test_console_scripts.py::test_console_scripts_help[subprocess-design2params]
4.47s call     tests/test_console_scripts.py::test_console_scripts_help[subprocess-design_kw]
4.27s call     tests/test_console_scripts.py::test_console_scripts_help[subprocess-csv_export2]
0.01s setup    tests/test_console_scripts.py::test_console_scripts_help[subprocess-csv_export2]
0.01s setup    tests/test_console_scripts.py::test_console_scripts_help[subprocess-design2params]
```
After:
```
4.92s call     tests/test_console_scripts.py::test_that_console_scripts_are_installed_and_their_help_command_returns_exit_code_0
0.01s setup    tests/test_console_scripts.py::test_that_console_scripts_are_installed_and_their_help_command_returns_exit_code_0
0.00s teardown tests/test_console_scripts.py::test_that_console_scripts_are_installed_and_their_help_command_returns_exit_code_0
```

Benchmarked in CI:
Before:
```
5.01s call     tests/test_console_scripts.py::test_console_scripts_help[subprocess-design_kw]
4.73s call     tests/test_console_scripts.py::test_console_scripts_help[subprocess-design2params]
4.43s call     tests/test_console_scripts.py::test_console_scripts_help[subprocess-fm_pyscal]
4.42s call     tests/test_console_scripts.py::test_console_scripts_help[subprocess-gendata_rft]
4.32s call     tests/test_console_scripts.py::test_console_scripts_help[subprocess-overburden_timeshift]
3.46s call     tests/test_console_scripts.py::test_console_scripts_help[subprocess-csv_export2]
```
After:
```
0.04s call     tests/test_console_scripts.py::test_that_console_scripts_are_installed_and_their_help_command_returns_exit_code_0
```
