### PR TITLE
Change from pandas to polars in GeneralInput

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ dependencies = [
     "seaborn",
     "probabilit>=0.4.1",
     "resfo-utilities>=0.1.1",
+    "polars",
+    "fastexcel",
 ]
 [dependency-groups]
 dev = [
@@ -61,7 +63,8 @@ dev = [
     'types-openpyxl',
     'types-seaborn',
     'types-setuptools',
-    'xlwt'
+    'xlwt',
+    'xlsxwriter'
 ]
 
 [project.urls]

--- a/src/semeio/fmudesign/_excel_to_dict.py
+++ b/src/semeio/fmudesign/_excel_to_dict.py
@@ -10,7 +10,6 @@ from typing import Any, Literal, cast
 
 import openpyxl
 import pandas as pd
-import polars as pl
 import yaml
 
 from semeio.fmudesign.general_input import GeneralInput
@@ -22,28 +21,6 @@ from semeio.fmudesign.utils import (
     resolve_path,
     seeds_from_extern,
 )
-
-
-def _read_general_input(
-    input_filename: str, general_input_sheet: str
-) -> dict[str, str | None]:
-    df = pl.read_excel(
-        input_filename,
-        sheet_name=general_input_sheet,
-        has_header=False,
-        read_options={"dtypes": "string"},
-        columns=[0, 1],
-    )
-    df = df.with_columns(
-        pl.col(col).str.strip_chars().alias(col) for col in df.columns
-    ).with_columns(
-        pl.when(pl.col(df.columns[1]).str.to_lowercase().is_in(["none", "null"]))
-        .then(None)
-        .otherwise(pl.col(df.columns[1]))
-        .alias(df.columns[1])
-    )
-    df = df.filter(pl.any_horizontal(pl.all().is_not_null()))
-    return dict(df.rows())
 
 
 def excel_to_dict(
@@ -75,9 +52,7 @@ def excel_to_dict(
     design_input_sheet = find_sheet(design_input_sheet, names=xlsx.sheetnames)
     default_values_sheet = find_sheet(default_values_sheet, names=xlsx.sheetnames)
 
-    general_input_dict = _read_general_input(input_filename, general_input_sheet)
-
-    general_input = GeneralInput.from_dict(general_input_dict, input_filename)
+    general_input = GeneralInput.from_xlsx(input_filename, general_input_sheet)
 
     return _excel_to_dict_onebyone(
         input_filename=input_filename,

--- a/src/semeio/fmudesign/_excel_to_dict.py
+++ b/src/semeio/fmudesign/_excel_to_dict.py
@@ -10,6 +10,7 @@ from typing import Any, Literal, cast
 
 import openpyxl
 import pandas as pd
+import polars as pl
 import yaml
 
 from semeio.fmudesign.general_input import GeneralInput
@@ -25,21 +26,24 @@ from semeio.fmudesign.utils import (
 
 def _read_general_input(
     input_filename: str, general_input_sheet: str
-) -> dict[str, Any]:
-    general_input = (
-        pd.read_excel(
-            input_filename,
-            general_input_sheet,
-            header=None,
-            engine="openpyxl",
-        )
-        .dropna(axis=0, how="all")
-        .dropna(axis=1, how="all")
-        .set_index(0)
-        .loc[:, 1]
-        .to_dict()
+) -> dict[str, str | None]:
+    df = pl.read_excel(
+        input_filename,
+        sheet_name=general_input_sheet,
+        has_header=False,
+        read_options={"dtypes": "string"},
+        columns=[0, 1],
     )
-    return {str(k): v for k, v in general_input.items()}
+    df = df.with_columns(
+        pl.col(col).str.strip_chars().alias(col) for col in df.columns
+    ).with_columns(
+        pl.when(pl.col(df.columns[1]).str.to_lowercase().is_in(["none", "null"]))
+        .then(None)
+        .otherwise(pl.col(df.columns[1]))
+        .alias(df.columns[1])
+    )
+    df = df.filter(pl.any_horizontal(pl.all().is_not_null()))
+    return dict(df.rows())
 
 
 def excel_to_dict(

--- a/src/semeio/fmudesign/general_input.py
+++ b/src/semeio/fmudesign/general_input.py
@@ -43,7 +43,11 @@ class GeneralInput(BaseModel):
         df = df.with_columns(
             pl.col(col).str.strip_chars().alias(col) for col in df.columns
         ).with_columns(
-            pl.when(pl.col(df.columns[1]).str.to_lowercase().is_in(["none", "null"]))
+            pl.when(
+                pl.col(df.columns[1])
+                .str.to_lowercase()
+                .is_in({"none", "null", "na", "nan"})
+            )
             .then(None)
             .otherwise(pl.col(df.columns[1]))
             .alias(df.columns[1])

--- a/src/semeio/fmudesign/general_input.py
+++ b/src/semeio/fmudesign/general_input.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Literal, Self
 
+import polars as pl
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -27,6 +28,37 @@ class GeneralInput(BaseModel):
     background: FilePath | str | None = None
 
     model_config = ConfigDict(extra="forbid", use_enum_values=True)
+
+    @staticmethod
+    def _read_general_input(
+        input_filename: str, general_input_sheet: str
+    ) -> dict[str, str | None]:
+        df = pl.read_excel(
+            input_filename,
+            sheet_name=general_input_sheet,
+            has_header=False,
+            read_options={"dtypes": "string"},
+            columns=[0, 1],
+        )
+        df = df.with_columns(
+            pl.col(col).str.strip_chars().alias(col) for col in df.columns
+        ).with_columns(
+            pl.when(pl.col(df.columns[1]).str.to_lowercase().is_in(["none", "null"]))
+            .then(None)
+            .otherwise(pl.col(df.columns[1]))
+            .alias(df.columns[1])
+        )
+        df = df.filter(pl.any_horizontal(pl.all().is_not_null()))
+        df = df.with_columns(pl.col(df.columns[0]).fill_null(""))
+        return dict(df.rows())
+
+    @classmethod
+    def from_xlsx(cls, input_filename: str, general_input_sheet: str) -> Self:
+        input_dict = cls._read_general_input(input_filename, general_input_sheet)
+        return cls.from_dict(
+            input_dict,
+            input_filename,
+        )
 
     @classmethod
     def from_dict(

--- a/src/semeio/fmudesign/general_input.py
+++ b/src/semeio/fmudesign/general_input.py
@@ -1,8 +1,6 @@
-from collections.abc import Collection
 from pathlib import Path
-from typing import Any, Literal, Self
+from typing import Literal, Self
 
-import pandas as pd
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -15,15 +13,6 @@ from pydantic import (
 
 from semeio.fmudesign.config_validation import SeedStrategy
 from semeio.fmudesign.utils import resolve_path
-
-
-def parse_value(value: object) -> object:
-    if isinstance(value, str):
-        return value.strip()
-    # pd.isna(Collection) -> NDArray, which is ambiguous
-    if not isinstance(value, Collection) and pd.isna(value):  # type: ignore[call-overload]
-        return None
-    return value
 
 
 class GeneralInput(BaseModel):
@@ -40,26 +29,13 @@ class GeneralInput(BaseModel):
     model_config = ConfigDict(extra="forbid", use_enum_values=True)
 
     @classmethod
-    def from_dict(cls, inputdict: dict[str, Any], input_filename: str = "") -> Self:
-        general_input: dict[str, Any] = {
-            str(key).strip(): parse_value(value) for key, value in inputdict.items()
-        }
-
-        # Boolean values are interpreted as valid ints, and are not caught by
-        # pydantic's validation. It can be caught using strict=True, but that
-        # removes the flexibility of allowing numeric strings for numeric fields.
-        # No values should be boolean, so we check for all.
-        for key, value in general_input.items():
-            if isinstance(value, bool):
-                raise ValueError(
-                    f"key '{key}' cannot have boolean value, got '{value}'"
-                )
+    def from_dict(
+        cls, input_dict: dict[str, str | None], input_filename: str = ""
+    ) -> Self:
+        general_input: dict[str, str | Path | None] = dict(input_dict.items())
 
         for key in ["seed_strategy", "correlation_iterations"]:
-            val = general_input.get(key)
-            is_none = general_input.get(key) is None
-            is_none_str = isinstance(val, str) and val.lower() == "none"
-            if is_none or is_none_str:
+            if general_input.get(key) is None:
                 print(
                     f"'{key}' not set in general input sheet. "
                     f"Setting to default "
@@ -68,16 +44,12 @@ class GeneralInput(BaseModel):
                 general_input.pop(key, None)
 
         for key in ["rms_seeds", "background"]:
-            val = general_input.get(key)
-            if isinstance(val, str):
+            if isinstance((val := general_input.get(key)), str):
                 resolved = resolve_path(val, base_file=input_filename)
                 assert isinstance(resolved, str)
-                if Path(resolved).exists():
-                    general_input[key] = Path(resolved)
-                elif resolved.lower() == "none":
-                    general_input[key] = None
-                else:
-                    general_input[key] = resolved
+                general_input[key] = (
+                    Path(resolved) if Path(resolved).is_file() else resolved
+                )
 
         return cls(**general_input)
 

--- a/tests/fmudesign/test_excel_to_dict.py
+++ b/tests/fmudesign/test_excel_to_dict.py
@@ -7,6 +7,7 @@ import numpy as np
 import openpyxl
 import pandas as pd
 import pytest
+import xlsxwriter
 
 from semeio.fmudesign import excel_to_dict, inputdict_to_yaml
 from semeio.fmudesign._excel_to_dict import (
@@ -373,12 +374,12 @@ def test_excel_to_dict_passes_seed_strategy(tmp_path):
 
 def _rows_to_xlsx_bytestream(rows: list[list[Any]]) -> BytesIO:
     excel_stream = BytesIO()
-    wb = openpyxl.Workbook()
-    ws = wb.active
-    ws.title = "general_input"
-    for row in rows:
-        ws.append(row)
-    wb.save(excel_stream)
+    wb = xlsxwriter.Workbook(excel_stream, {"in_memory": True})
+    ws = wb.add_worksheet("general_input")
+    for row_idx, row in enumerate(rows):
+        for col_idx, value in enumerate(row):
+            ws.write(row_idx, col_idx, value)
+    wb.close()
     return excel_stream
 
 
@@ -395,9 +396,9 @@ def test_that_columns_in_excel_is_reduced_to_first_two_in_read_general_input():
 
     assert result == {
         "designtype": "onebyone",
-        "repeats": 10,
+        "repeats": "10",
         "rms_seeds": "default",
-        "distribution_seed": np.nan,
+        "distribution_seed": None,
     }
 
 
@@ -420,30 +421,35 @@ def test_that_empty_rows_in_excel_is_filtered_out_in_read_general_input():
 
     assert result == {
         "designtype": "onebyone",
-        "repeats": 10,
+        "repeats": "10",
         "rms_seeds": "default",
-        "distribution_seed": np.nan,
+        "distribution_seed": None,
     }
 
 
-@pytest.mark.parametrize("none", [None, "None", "null", "NULL"])
-def test_that_null_rows_in_excel_is_filtered_out_in_read_general_input(none):
+@pytest.mark.parametrize(
+    "none_like", [None, "none", "None", "NONE", " None ", "null", "NULL", " null "]
+)
+def test_that_null_rows_in_excel_is_filtered_out_in_read_general_input(none_like):
+    """This tests that various none like values are interpreted as None and filtered
+    out when the keyword to the corresponding value is an empty cell."""
+    empty_cell = ""
+    rows = [["foo", "bar"], [empty_cell, none_like]]
+
+    xlsx_stream = _rows_to_xlsx_bytestream(rows)
+    result = _read_general_input(xlsx_stream, "general_input")
+
+    assert result == {"foo": "bar"}
+
+
+def test_that_null_keyword_in_excel_is_not_cast_to_none_type():
     rows = [
         ["designtype", "onebyone"],
-        [none, ""],
-        ["", none],
-        [none, none],
-        ["repeats", 10],
-        ["rms_seeds", "default"],
-        ["distribution_seed", none],
+        ["none", "none"],
     ]
 
     xlsx_stream = _rows_to_xlsx_bytestream(rows)
     result = _read_general_input(xlsx_stream, "general_input")
 
-    assert result == {
-        "designtype": "onebyone",
-        "repeats": 10,
-        "rms_seeds": "default",
-        "distribution_seed": np.nan,
-    }
+    assert "none" in result
+    assert result["none"] is None

--- a/tests/fmudesign/test_excel_to_dict.py
+++ b/tests/fmudesign/test_excel_to_dict.py
@@ -1,12 +1,19 @@
 """Testing excel_to_dict"""
 
+from io import BytesIO
+from typing import Any
+
 import numpy as np
 import openpyxl
 import pandas as pd
 import pytest
 
 from semeio.fmudesign import excel_to_dict, inputdict_to_yaml
-from semeio.fmudesign._excel_to_dict import _assert_no_merged_cells, _has_value
+from semeio.fmudesign._excel_to_dict import (
+    _assert_no_merged_cells,
+    _has_value,
+    _read_general_input,
+)
 
 MOCK_GENERAL_INPUT = pd.DataFrame(
     data=[
@@ -362,3 +369,81 @@ def test_excel_to_dict_passes_seed_strategy(tmp_path):
     )
     dict_design = excel_to_dict(input_path)
     assert dict_design["seed_strategy"] == "independent"
+
+
+def _rows_to_xlsx_bytestream(rows: list[list[Any]]) -> BytesIO:
+    excel_stream = BytesIO()
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "general_input"
+    for row in rows:
+        ws.append(row)
+    wb.save(excel_stream)
+    return excel_stream
+
+
+def test_that_columns_in_excel_is_reduced_to_first_two_in_read_general_input():
+    rows = [
+        ["designtype", "onebyone", "third_column", "fourth_column"],
+        ["repeats", 10, "third_column", "fourth_column"],
+        ["rms_seeds", "default", "third_column", "fourth_column"],
+        ["distribution_seed", None, "third_column", "fourth_column"],
+    ]
+    xlsx_stream = _rows_to_xlsx_bytestream(rows)
+
+    result = _read_general_input(xlsx_stream, "general_input")
+
+    assert result == {
+        "designtype": "onebyone",
+        "repeats": 10,
+        "rms_seeds": "default",
+        "distribution_seed": np.nan,
+    }
+
+
+def test_that_empty_rows_in_excel_is_filtered_out_in_read_general_input():
+    empty_row = ["", ""]
+    rows = [
+        empty_row,
+        ["designtype", "onebyone"],
+        empty_row,
+        ["repeats", 10],
+        empty_row,
+        ["rms_seeds", "default"],
+        empty_row,
+        ["distribution_seed", None],
+        empty_row,
+    ]
+
+    xlsx_stream = _rows_to_xlsx_bytestream(rows)
+    result = _read_general_input(xlsx_stream, "general_input")
+
+    assert result == {
+        "designtype": "onebyone",
+        "repeats": 10,
+        "rms_seeds": "default",
+        "distribution_seed": np.nan,
+    }
+
+
+@pytest.mark.parametrize("none", [None, "None", "null", "NULL"])
+def test_that_null_rows_in_excel_is_filtered_out_in_read_general_input(none):
+    rows = [
+        ["designtype", "onebyone"],
+        [none, ""],
+        ["", none],
+        [none, none],
+        ["repeats", 10],
+        ["rms_seeds", "default"],
+        ["distribution_seed", none],
+    ]
+
+    xlsx_stream = _rows_to_xlsx_bytestream(rows)
+    result = _read_general_input(xlsx_stream, "general_input")
+
+    assert result == {
+        "designtype": "onebyone",
+        "repeats": 10,
+        "rms_seeds": "default",
+        "distribution_seed": np.nan,
+    }

--- a/tests/fmudesign/test_excel_to_dict.py
+++ b/tests/fmudesign/test_excel_to_dict.py
@@ -1,19 +1,14 @@
 """Testing excel_to_dict"""
 
-from io import BytesIO
-from typing import Any
-
 import numpy as np
 import openpyxl
 import pandas as pd
 import pytest
-import xlsxwriter
 
 from semeio.fmudesign import excel_to_dict, inputdict_to_yaml
 from semeio.fmudesign._excel_to_dict import (
     _assert_no_merged_cells,
     _has_value,
-    _read_general_input,
 )
 
 MOCK_GENERAL_INPUT = pd.DataFrame(
@@ -370,86 +365,3 @@ def test_excel_to_dict_passes_seed_strategy(tmp_path):
     )
     dict_design = excel_to_dict(input_path)
     assert dict_design["seed_strategy"] == "independent"
-
-
-def _rows_to_xlsx_bytestream(rows: list[list[Any]]) -> BytesIO:
-    excel_stream = BytesIO()
-    wb = xlsxwriter.Workbook(excel_stream, {"in_memory": True})
-    ws = wb.add_worksheet("general_input")
-    for row_idx, row in enumerate(rows):
-        for col_idx, value in enumerate(row):
-            ws.write(row_idx, col_idx, value)
-    wb.close()
-    return excel_stream
-
-
-def test_that_columns_in_excel_is_reduced_to_first_two_in_read_general_input():
-    rows = [
-        ["designtype", "onebyone", "third_column", "fourth_column"],
-        ["repeats", 10, "third_column", "fourth_column"],
-        ["rms_seeds", "default", "third_column", "fourth_column"],
-        ["distribution_seed", None, "third_column", "fourth_column"],
-    ]
-    xlsx_stream = _rows_to_xlsx_bytestream(rows)
-
-    result = _read_general_input(xlsx_stream, "general_input")
-
-    assert result == {
-        "designtype": "onebyone",
-        "repeats": "10",
-        "rms_seeds": "default",
-        "distribution_seed": None,
-    }
-
-
-def test_that_empty_rows_in_excel_is_filtered_out_in_read_general_input():
-    empty_row = ["", ""]
-    rows = [
-        empty_row,
-        ["designtype", "onebyone"],
-        empty_row,
-        ["repeats", 10],
-        empty_row,
-        ["rms_seeds", "default"],
-        empty_row,
-        ["distribution_seed", None],
-        empty_row,
-    ]
-
-    xlsx_stream = _rows_to_xlsx_bytestream(rows)
-    result = _read_general_input(xlsx_stream, "general_input")
-
-    assert result == {
-        "designtype": "onebyone",
-        "repeats": "10",
-        "rms_seeds": "default",
-        "distribution_seed": None,
-    }
-
-
-@pytest.mark.parametrize(
-    "none_like", [None, "none", "None", "NONE", " None ", "null", "NULL", " null "]
-)
-def test_that_null_rows_in_excel_is_filtered_out_in_read_general_input(none_like):
-    """This tests that various none like values are interpreted as None and filtered
-    out when the keyword to the corresponding value is an empty cell."""
-    empty_cell = ""
-    rows = [["foo", "bar"], [empty_cell, none_like]]
-
-    xlsx_stream = _rows_to_xlsx_bytestream(rows)
-    result = _read_general_input(xlsx_stream, "general_input")
-
-    assert result == {"foo": "bar"}
-
-
-def test_that_null_keyword_in_excel_is_not_cast_to_none_type():
-    rows = [
-        ["designtype", "onebyone"],
-        ["none", "none"],
-    ]
-
-    xlsx_stream = _rows_to_xlsx_bytestream(rows)
-    result = _read_general_input(xlsx_stream, "general_input")
-
-    assert "none" in result
-    assert result["none"] is None

--- a/tests/fmudesign/test_general_input.py
+++ b/tests/fmudesign/test_general_input.py
@@ -1,17 +1,12 @@
 from pathlib import Path
-from types import NoneType
-from typing import Any
 
 import hypothesis.strategies as st
-import numpy as np
-import pandas as pd
 import pytest
 from hypothesis import assume, given
 from pydantic import TypeAdapter, ValidationError
 
-from semeio.fmudesign._excel_to_dict import GeneralInput
 from semeio.fmudesign.config_validation import SeedStrategy
-from semeio.fmudesign.general_input import parse_value
+from semeio.fmudesign.general_input import GeneralInput
 
 PYDANTIC_PATH_ERROR = "Path does not point to a file|Input is not a valid path"
 
@@ -19,58 +14,28 @@ PYDANTIC_PATH_ERROR = "Path does not point to a file|Input is not a valid path"
 def base_general_input_dict():
     return {
         "designtype": "onebyone",
-        "repeats": 10,
+        "repeats": "10",
         "distribution_seed": None,
         "rms_seeds": None,
-        "correlation_iterations": 1,
+        "correlation_iterations": "1",
         "seed_strategy": SeedStrategy.JOINT,
         "background": None,
     }
 
 
-ANY_TYPE = st.one_of(
-    st.integers(),
-    st.floats(allow_nan=False),
-    st.text(),
-    st.booleans(),
-    st.none(),
-    st.lists(st.integers(), min_size=1),
-    st.dictionaries(st.text(), st.integers() | st.text(), min_size=1),
-)
-
-
-_int_adapter = TypeAdapter(int)
-_float_adapter = TypeAdapter(float)
-
-
 def is_pydantic_numeric(x):
-    for adapter in (_int_adapter, _float_adapter):
+    for adapter in (TypeAdapter(int), TypeAdapter(float)):
         try:
-            adapter.validate_python(x)
+            adapter.validate_python(x.strip())
             return True
         except ValidationError:
             pass
     return False
 
 
-NON_NUMERIC = ANY_TYPE.filter(lambda x: not is_pydantic_numeric(x))
-
-
-BOOLEAN_ERROR = "cannot have boolean value"
-
-
-@pytest.mark.parametrize(
-    "nan_value",
-    [
-        float("nan"),
-        np.nan,
-        np.float64("nan"),
-        pd.NaT,
-        None,
-    ],
-)
-def test_that_parse_value_converts_nan_formats_to_none(nan_value):
-    assert parse_value(nan_value) is None
+TEXT_STRIPPED = st.text().map(str.strip)
+TEXT_STRIPPED_NOT_NUMERIC = TEXT_STRIPPED.filter(lambda x: not is_pydantic_numeric(x))
+TEXT_STRIPPED_OR_NONE = st.one_of(TEXT_STRIPPED_NOT_NUMERIC, st.none())
 
 
 @pytest.mark.parametrize(
@@ -97,20 +62,7 @@ def test_that_missing_optional_keys_does_not_raise_validation_error(optional_key
 def test_that_extra_key_raises_value_error():
     extra = {"extra_key": "foo"}
     with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
-        GeneralInput(
-            designtype="onebyone",
-            repeats=1,
-            distribution_seed=42,
-            rms_seeds="default",
-            **extra,
-        )
-
-
-def test_that_whitespace_around_keys_is_stripped():
-    general_input_dict = base_general_input_dict()
-    general_input_dict[" repeats "] = general_input_dict.pop("repeats")
-    result = GeneralInput.from_dict(general_input_dict)
-    assert result.repeats == 10
+        GeneralInput.from_dict(base_general_input_dict() | extra)
 
 
 def test_that_designtype_onebyone_is_accepted():
@@ -118,36 +70,36 @@ def test_that_designtype_onebyone_is_accepted():
     assert result.designtype == "onebyone"
 
 
-@given(ANY_TYPE)
+@given(TEXT_STRIPPED)
 def test_that_other_design_types_than_onebyone_raises_validation_error(text):
     assume(text != "onebyone")
     general_input_dict = base_general_input_dict() | {"designtype": text}
-    with pytest.raises(ValueError, match=f"Input should be 'onebyone'|{BOOLEAN_ERROR}"):
+    with pytest.raises(ValueError, match="Input should be 'onebyone'"):
         GeneralInput.from_dict(general_input_dict)
 
 
 @given(st.integers(min_value=1, max_value=10000))
 def test_that_positive_int_repeats_is_accepted(positive_int):
-    general_input_dict = base_general_input_dict() | {"repeats": positive_int}
+    general_input_dict = base_general_input_dict() | {"repeats": str(positive_int)}
     result = GeneralInput.from_dict(general_input_dict)
     assert result.repeats == positive_int
 
 
 def test_that_zero_repeats_raises_validation_error():
-    general_input_dict = base_general_input_dict() | {"repeats": 0}
+    general_input_dict = base_general_input_dict() | {"repeats": "0"}
     with pytest.raises(ValidationError, match="repeats"):
         GeneralInput.from_dict(general_input_dict)
 
 
 def test_that_negative_repeats_raises_validation_error():
-    general_input_dict = base_general_input_dict() | {"repeats": -1}
+    general_input_dict = base_general_input_dict() | {"repeats": "-1"}
     with pytest.raises(ValidationError):
         GeneralInput.from_dict(general_input_dict)
 
 
-@given(NON_NUMERIC)
+@given(TEXT_STRIPPED_NOT_NUMERIC)
 def test_that_non_integer_repeats_raises_validation_error(non_int):
-    general_input_dict = base_general_input_dict() | {"repeats": non_int}
+    general_input_dict = base_general_input_dict() | {"repeats": str(non_int)}
     with pytest.raises(
         ValidationError,
         match=r"Input should be greater than 0|Input should be a valid integer",
@@ -155,19 +107,9 @@ def test_that_non_integer_repeats_raises_validation_error(non_int):
         GeneralInput.from_dict(general_input_dict)
 
 
-@pytest.mark.parametrize("bool_", [True, False])
-def test_that_true_false_are_rejected_for_repeats(bool_):
-    input_dict = base_general_input_dict() | {"repeats": bool_}
-    with pytest.raises(
-        ValueError,
-        match=BOOLEAN_ERROR,
-    ):
-        GeneralInput.from_dict(input_dict)
-
-
 @given(st.integers(min_value=0))
 def test_that_non_negative_distribution_seed_is_accepted(value):
-    general_input_dict = base_general_input_dict() | {"distribution_seed": value}
+    general_input_dict = base_general_input_dict() | {"distribution_seed": str(value)}
     result = GeneralInput.from_dict(general_input_dict)
     assert result.distribution_seed == value
 
@@ -180,12 +122,12 @@ def test_that_none_distribution_seed_is_accepted():
 
 @given(st.integers(max_value=-1))
 def test_that_negative_distribution_seed_raises_validation_error(value):
-    general_input_dict = base_general_input_dict() | {"distribution_seed": value}
+    general_input_dict = base_general_input_dict() | {"distribution_seed": str(value)}
     with pytest.raises(ValidationError):
         GeneralInput.from_dict(general_input_dict)
 
 
-@given(NON_NUMERIC.filter(lambda x: not isinstance(x, NoneType)))
+@given(TEXT_STRIPPED_NOT_NUMERIC)
 def test_that_invalid_distribution_seed_types_raises_validation_error(
     invalid_distribution_seed,
 ):
@@ -194,16 +136,6 @@ def test_that_invalid_distribution_seed_types_raises_validation_error(
     }
     with pytest.raises(ValidationError, match="Input should be a valid integer"):
         GeneralInput.from_dict(general_input_dict)
-
-
-@pytest.mark.parametrize("bool_", [True, False])
-def test_that_true_false_are_rejected_for_distribution_seed(bool_):
-    input_dict = base_general_input_dict() | {"distribution_seed": bool_}
-    with pytest.raises(
-        ValueError,
-        match=BOOLEAN_ERROR,
-    ):
-        GeneralInput.from_dict(input_dict)
 
 
 def test_that_rms_seeds_none_is_accepted():
@@ -251,15 +183,12 @@ def test_that_rms_seeds_from_extern_csv_file_in_subdirectory_is_accepted(use_tmp
     assert result.rms_seeds == (subdir / seeds_file_name).resolve()
 
 
-@given(ANY_TYPE.filter(lambda x: not isinstance(x, list | NoneType)))
+@given(TEXT_STRIPPED)
 def test_that_invalid_rms_seeds_types_raises_validation_error(invalid_rms_seeds):
     assume(invalid_rms_seeds != "default")
     general_input_dict = base_general_input_dict() | {"rms_seeds": invalid_rms_seeds}
     with pytest.raises(
-        ValueError,
-        match=f"Path does not point to a file"
-        f"|Input is not a valid path"
-        f"|{BOOLEAN_ERROR}",
+        ValueError, match=r"Path does not point to a file|Input is not a valid path"
     ):
         GeneralInput.from_dict(general_input_dict)
 
@@ -273,7 +202,13 @@ def test_that_rms_seeds_from_external_txt_file_is_resolved(use_tmpdir):
     assert gi.rms_seeds == Path(seeds_file_name).resolve()
 
 
-def test_that_correlation_iterations_defaults_to_zero():
+def test_that_none_correlation_iterations_defaults_to_zero():
+    general_input_dict = base_general_input_dict() | {"correlation_iterations": None}
+    result = GeneralInput.from_dict(general_input_dict)
+    assert result.correlation_iterations == 0
+
+
+def test_that_missing_correlation_iterations_defaults_to_zero():
     general_input_dict = base_general_input_dict()
     general_input_dict.pop("correlation_iterations")
     result = GeneralInput.from_dict(general_input_dict)
@@ -283,13 +218,13 @@ def test_that_correlation_iterations_defaults_to_zero():
 @given(st.integers(min_value=0))
 def test_that_non_negative_correlation_iterations_is_accepted(value):
     general_input_dict = base_general_input_dict() | {
-        "correlation_iterations": value,
+        "correlation_iterations": str(value),
     }
     result = GeneralInput.from_dict(general_input_dict)
     assert result.correlation_iterations == value
 
 
-@given(NON_NUMERIC.filter(lambda x: not isinstance(x, NoneType)))
+@given(TEXT_STRIPPED_NOT_NUMERIC)
 def test_that_invalid_correlation_iterations_raises_validation_error(
     invalid_correlation_iterations,
 ):
@@ -302,23 +237,19 @@ def test_that_invalid_correlation_iterations_raises_validation_error(
 
 def test_that_negative_correlation_iterations_raises_validation_error():
     general_input_dict = base_general_input_dict() | {
-        "correlation_iterations": -1,
+        "correlation_iterations": "-1",
     }
     with pytest.raises(ValidationError):
         GeneralInput.from_dict(general_input_dict)
 
 
-@pytest.mark.parametrize("bool_", [True, False])
-def test_that_true_false_are_rejected_for_correlation_iterations(bool_):
-    input_dict = base_general_input_dict() | {"correlation_iterations": bool_}
-    with pytest.raises(
-        ValueError,
-        match=BOOLEAN_ERROR,
-    ):
-        GeneralInput.from_dict(input_dict)
+def test_that_none_seed_strategy_defaults_to_joint():
+    general_input_dict = base_general_input_dict() | {"seed_strategy": None}
+    result = GeneralInput.from_dict(general_input_dict)
+    assert result.seed_strategy == SeedStrategy.JOINT
 
 
-def test_that_seed_strategy_defaults_to_joint():
+def test_that_missing_seed_strategy_defaults_to_joint():
     general_input_dict = base_general_input_dict()
     general_input_dict.pop("seed_strategy")
     result = GeneralInput.from_dict(general_input_dict)
@@ -339,17 +270,18 @@ def test_that_valid_seed_strategies_are_accepted(strategy):
     assert result.seed_strategy == strategy
 
 
-def _not_seed_strategy_or_none_str(x: Any):
-    return not isinstance(x, str) or x.lower() not in {*SeedStrategy, "none"}
+TEXT_OR_NONE_NOT_IN_SEED_STRATEGY = TEXT_STRIPPED_OR_NONE.filter(
+    lambda x: isinstance(x, str) and x not in SeedStrategy
+)
 
 
-@given(ANY_TYPE.filter(_not_seed_strategy_or_none_str).filter(lambda x: x is not None))
+@given(TEXT_OR_NONE_NOT_IN_SEED_STRATEGY)
 def test_that_invalid_seed_strategy_raises_validation_error(invalid_seed_strategy):
     general_input_dict = base_general_input_dict() | {
         "seed_strategy": invalid_seed_strategy
     }
     seed_strategy_error = "Input should be 'joint' or 'independent'"
-    with pytest.raises(ValueError, match=f"{BOOLEAN_ERROR}|{seed_strategy_error}"):
+    with pytest.raises(ValueError, match=seed_strategy_error):
         GeneralInput.from_dict(general_input_dict)
 
 
@@ -360,13 +292,6 @@ def test_that_seed_strategy_is_serialized_as_str():
 
 def test_that_background_none_is_accepted():
     general_input_dict = base_general_input_dict() | {"background": None}
-    result = GeneralInput.from_dict(general_input_dict)
-    assert result.background is None
-
-
-@pytest.mark.parametrize("value", ["None", "none", "NONE"])
-def test_that_background_none_like_strings_are_treated_as_none(value):
-    general_input_dict = base_general_input_dict() | {"background": value}
     result = GeneralInput.from_dict(general_input_dict)
     assert result.background is None
 

--- a/tests/fmudesign/test_general_input.py
+++ b/tests/fmudesign/test_general_input.py
@@ -1,7 +1,11 @@
+import string
+from io import BytesIO
 from pathlib import Path
+from typing import Any
 
 import hypothesis.strategies as st
 import pytest
+import xlsxwriter
 from hypothesis import assume, given
 from pydantic import TypeAdapter, ValidationError
 
@@ -353,3 +357,150 @@ def test_that_background_path_is_serialized_as_string():
 def test_that_serialize_paths_doesnt_fail_given_none():
     gi = GeneralInput.from_dict(base_general_input_dict())
     assert gi.model_dump()["background"] is None
+
+
+def _rows_to_xlsx_bytestream(rows: list[list[Any]]) -> BytesIO:
+    excel_stream = BytesIO()
+    wb = xlsxwriter.Workbook(excel_stream, {"in_memory": True})
+    ws = wb.add_worksheet("general_input")
+    for row_idx, row in enumerate(rows):
+        for col_idx, value in enumerate(row):
+            ws.write(row_idx, col_idx, value)
+    wb.close()
+    return excel_stream
+
+
+def test_that_columns_in_excel_is_reduced_to_first_two_in_read_general_input():
+    rows = [
+        ["designtype", "onebyone", "third_column", "fourth_column"],
+        ["repeats", 10, "third_column", "fourth_column"],
+        ["rms_seeds", "default", "third_column", "fourth_column"],
+        ["distribution_seed", None, "third_column", "fourth_column"],
+    ]
+    xlsx_stream = _rows_to_xlsx_bytestream(rows)
+
+    result = GeneralInput._read_general_input(xlsx_stream, "general_input")
+
+    assert result == {
+        "designtype": "onebyone",
+        "repeats": "10",
+        "rms_seeds": "default",
+        "distribution_seed": None,
+    }
+
+
+def test_that_empty_rows_in_excel_is_filtered_out_in_read_general_input():
+    empty_row = ["", ""]
+    rows = [
+        empty_row,
+        ["designtype", "onebyone"],
+        empty_row,
+        ["repeats", 10],
+        empty_row,
+        ["rms_seeds", "default"],
+        empty_row,
+        ["distribution_seed", None],
+        empty_row,
+    ]
+
+    xlsx_stream = _rows_to_xlsx_bytestream(rows)
+    result = GeneralInput._read_general_input(xlsx_stream, "general_input")
+
+    assert result == {
+        "designtype": "onebyone",
+        "repeats": "10",
+        "rms_seeds": "default",
+        "distribution_seed": None,
+    }
+
+
+@pytest.mark.parametrize(
+    "none_like", [None, "none", "None", "NONE", " None ", "null", "NULL", " null "]
+)
+def test_that_none_rows_in_excel_is_filtered_out_in_read_general_input(none_like):
+    """This tests that various none like values are interpreted as None and filtered
+    out when the keyword to the corresponding value is an empty cell."""
+    empty_cell = ""
+    rows = [["foo", "bar"], [empty_cell, none_like]]
+
+    xlsx_stream = _rows_to_xlsx_bytestream(rows)
+    result = GeneralInput._read_general_input(xlsx_stream, "general_input")
+
+    assert result == {"foo": "bar"}
+
+
+@pytest.mark.parametrize("none_like", ["none", "None", "NONE", "null", "NULL"])
+def test_that_none_keyword_in_excel_is_not_cast_to_none_type(none_like):
+    rows = [
+        ["designtype", "onebyone"],
+        [none_like, "none"],
+    ]
+    xlsx_stream = _rows_to_xlsx_bytestream(rows)
+    result = GeneralInput._read_general_input(xlsx_stream, "general_input")
+    assert None not in result
+    assert none_like in result
+    assert result[none_like] is None
+
+
+def test_that_empty_keyword_cell_in_excel_is_cast_to_empty_string():
+    rows = [
+        ["designtype", "onebyone"],
+        ["", "foo"],
+    ]
+    xlsx_stream = _rows_to_xlsx_bytestream(rows)
+
+    result = GeneralInput._read_general_input(xlsx_stream, "general_input")
+    assert None not in result
+    assert "" in result
+    assert result[""] == "foo"
+
+
+@given(
+    st.integers(min_value=1, max_value=1_000_000),
+    st.integers(min_value=0, max_value=1_000_000),
+    st.text(min_size=1, max_size=15, alphabet=string.ascii_letters).filter(
+        lambda x: x.lower() not in {"none", "null"}
+    ),
+    st.integers(min_value=0, max_value=1_000_000),
+    st.sampled_from(SeedStrategy),
+)
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.integration_test
+def test_that_from_xlsx_produce_general_input_with_excel_values(
+    repeats,
+    distribution_seed,
+    rms_seeds,
+    correlation_iterations,
+    seed_strategy,
+):
+    design_type = "onebyone"
+
+    if rms_seeds != "default":
+        Path(rms_seeds).touch()
+
+    rows = [
+        ["designtype", design_type],
+        ["repeats", repeats],
+        ["rms_seeds", rms_seeds],
+        ["distribution_seed", distribution_seed],
+        ["correlation_iterations", correlation_iterations],
+        ["seed_strategy", seed_strategy],
+    ]
+
+    xlsx_stream = _rows_to_xlsx_bytestream(rows)
+
+    design_file = "designinput.xlsx"
+    Path(design_file).write_bytes(xlsx_stream.getvalue())
+
+    gi = GeneralInput.from_xlsx(design_file, "general_input")
+
+    assert gi.designtype == design_type
+    assert gi.repeats == repeats
+    assert (
+        gi.rms_seeds == Path(rms_seeds).resolve()
+        if rms_seeds != "default"
+        else "default"
+    )
+    assert gi.distribution_seed == distribution_seed
+    assert gi.correlation_iterations == correlation_iterations
+    assert gi.seed_strategy == seed_strategy

--- a/tests/fmudesign/test_general_input.py
+++ b/tests/fmudesign/test_general_input.py
@@ -415,7 +415,20 @@ def test_that_empty_rows_in_excel_is_filtered_out_in_read_general_input():
 
 
 @pytest.mark.parametrize(
-    "none_like", [None, "none", "None", "NONE", " None ", "null", "NULL", " null "]
+    "none_like",
+    [
+        None,
+        "none",
+        "None",
+        "NONE",
+        " None ",
+        "null",
+        "NULL",
+        " null ",
+        "na",
+        "NA",
+        "NaN",
+    ],
 )
 def test_that_none_rows_in_excel_is_filtered_out_in_read_general_input(none_like):
     """This tests that various none like values are interpreted as None and filtered
@@ -459,7 +472,7 @@ def test_that_empty_keyword_cell_in_excel_is_cast_to_empty_string():
     st.integers(min_value=1, max_value=1_000_000),
     st.integers(min_value=0, max_value=1_000_000),
     st.text(min_size=1, max_size=15, alphabet=string.ascii_letters).filter(
-        lambda x: x.lower() not in {"none", "null"}
+        lambda x: x.lower() not in {"none", "null", "na", "nan"}
     ),
     st.integers(min_value=0, max_value=1_000_000),
     st.sampled_from(SeedStrategy),

--- a/uv.lock
+++ b/uv.lock
@@ -3740,9 +3740,11 @@ source = { editable = "." }
 dependencies = [
     { name = "cvxpy" },
     { name = "ert" },
+    { name = "fastexcel" },
     { name = "fmu-ensemble" },
     { name = "numpy" },
     { name = "pandas" },
+    { name = "polars" },
     { name = "probabilit" },
     { name = "pydantic" },
     { name = "pyscal" },
@@ -3775,6 +3777,7 @@ dev = [
     { name = "types-pyyaml" },
     { name = "types-seaborn" },
     { name = "types-setuptools" },
+    { name = "xlsxwriter" },
     { name = "xlwt" },
 ]
 
@@ -3782,9 +3785,11 @@ dev = [
 requires-dist = [
     { name = "cvxpy" },
     { name = "ert", specifier = ">=23.0.0b1.dev0" },
+    { name = "fastexcel" },
     { name = "fmu-ensemble", specifier = ">1.6.5" },
     { name = "numpy" },
     { name = "pandas", specifier = ">=2" },
+    { name = "polars" },
     { name = "probabilit", specifier = ">=0.4.1" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pyscal", specifier = ">=0.4.0" },
@@ -3817,6 +3822,7 @@ dev = [
     { name = "types-pyyaml" },
     { name = "types-seaborn" },
     { name = "types-setuptools" },
+    { name = "xlsxwriter" },
     { name = "xlwt" },
 ]
 
@@ -4293,6 +4299,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/07/5a/377161c2d3538d1990d7af382c79f3b2372e880b65de21b01b1a2b78691e/xlrd-2.0.2.tar.gz", hash = "sha256:08b5e25de58f21ce71dc7db3b3b8106c1fa776f3024c54e45b45b374e89234c9", size = 100167, upload-time = "2025-06-14T08:46:39.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/62/c8d562e7766786ba6587d09c5a8ba9f718ed3fa8af7f4553e8f91c36f302/xlrd-2.0.2-py2.py3-none-any.whl", hash = "sha256:ea762c3d29f4cca48d82df517b6d89fbce4db3107f9d78713e48cd321d5c9aa9", size = 96555, upload-time = "2025-06-14T08:46:37.766Z" },
+]
+
+[[package]]
+name = "xlsxwriter"
+version = "3.2.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940, upload-time = "2025-09-16T00:16:21.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315, upload-time = "2025-09-16T00:16:20.108Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
As polars have stricter typing of columns, the behavior is now changed to reading the excel file into all strings in the dataframe.
This new assumption eases some of the logic in `GeneralInput`, while we leave the casting to the correct datatypes to Pydantic.

At the same time, `_read_general_input` is moved into the `GeneralInput` class as a static method, as it is only used there.